### PR TITLE
Fixing brickstrap on Debian sid.

### DIFF
--- a/brickstrap.sh
+++ b/brickstrap.sh
@@ -244,7 +244,7 @@ function configure-packages () {
     info "preseed debconf"
     if [ -r "${BOARD}/debconfseed.txt" ]; then
         cp "${BOARD}/debconfseed.txt" "${ROOTDIR}/tmp/"
-        ${CHROOTQEMUCMD} ${ROOTDIR} debconf-set-selections /tmp/debconfseed.txt
+        ${CHROOTQEMUCMD} -r ${ROOTDIR} debconf-set-selections /tmp/debconfseed.txt
         rm "${ROOTDIR}/tmp/debconfseed.txt"
     fi
 
@@ -266,13 +266,13 @@ function configure-packages () {
         info "running ${script##$script_dir}"
         DPKG_MAINTSCRIPT_NAME=preinst \
         DPKG_MAINTSCRIPT_PACKAGE="`basename ${script} .preinst`" \
-            ${CHROOTQEMUBINDCMD} ${ROOTDIR} ${script##$ROOTDIR} install
+            ${CHROOTQEMUBINDCMD} -r ${ROOTDIR} ${script##$ROOTDIR} install
     done
 
     # run dpkg `--configure -a` twice because of errors during the first run
     info "configuring packages..."
-    ${CHROOTQEMUBINDCMD} ${ROOTDIR} /usr/bin/dpkg --configure -a || \
-    ${CHROOTQEMUBINDCMD} ${ROOTDIR} /usr/bin/dpkg --configure -a || true
+    ${CHROOTQEMUBINDCMD} -r ${ROOTDIR} /usr/bin/dpkg --configure -a || \
+    ${CHROOTQEMUBINDCMD} -r ${ROOTDIR} /usr/bin/dpkg --configure -a || true
 }
 
 function run-hooks() {
@@ -298,8 +298,8 @@ function create-tar() {
     # need to generate tar inside fakechroot so that absolute symlinks are correct
     info "creating tarball ${TARBALL}"
     info "Excluding files:
-$(${CHROOTQEMUCMD} ${ROOTDIR} cat host-rootfs${BOARD}/tar-exclude)"
-    ${CHROOTQEMUCMD} ${ROOTDIR} tar -cpf host-rootfs/${TARBALL} \
+$(${CHROOTQEMUCMD} -r ${ROOTDIR} cat host-rootfs${BOARD}/tar-exclude)"
+    ${CHROOTQEMUCMD} -r ${ROOTDIR} tar -cpf host-rootfs/${TARBALL} \
         --exclude=host-rootfs --exclude-from=host-rootfs${BOARD}/tar-exclude /
 }
 
@@ -334,7 +334,7 @@ function create-image() {
 
 function run-shell() {
     [ ! -d "${ROOTDIR}" ] && fail "${ROOTDIR} does not exist."
-    HOME=/root ${CHROOTQEMUBINDCMD} ${ROOTDIR} bash
+    HOME=/root ${CHROOTQEMUBINDCMD} -r ${ROOTDIR} bash
 }
 
 case "${cmd}" in

--- a/default/hooks/firstboot
+++ b/default/hooks/firstboot
@@ -22,4 +22,4 @@ done
 __END__
 
 chmod +x $ROOTDIR/etc/init.d/firstboot
-$CHROOTQEMUCMD $ROOTDIR update-rc.d firstboot start 99 S
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d firstboot start 99 S

--- a/ev3dev-jessie/hooks/console-setup
+++ b/ev3dev-jessie/hooks/console-setup
@@ -1,7 +1,7 @@
 echo -e -n "\nFONT='Lat15-TomThumb4x6.psf.gz'" >> $ROOTDIR/etc/default/console-setup
-$CHROOTQEMUCMD $ROOTDIR setupcon --save-only
+$CHROOTQEMUCMD -r $ROOTDIR setupcon --save-only
 # keyboard-setup takes long time during boot, so disabling for now.
-$CHROOTQEMUCMD $ROOTDIR update-rc.d keyboard-setup disable
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d keyboard-setup disable
 # `kbd` does the same thing as `console-setup`/`keyboard-setup`, so we disable it too,
 # Also, `kbd` breaks systemd, so we really don't want it enabled.
-$CHROOTQEMUCMD $ROOTDIR update-rc.d kbd disable
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d kbd disable

--- a/ev3dev-jessie/hooks/create-changelog-template
+++ b/ev3dev-jessie/hooks/create-changelog-template
@@ -22,6 +22,6 @@ Included Packages
 -----------------
 
 \`\`\`
-$($CHROOTQEMUCMD $ROOTDIR dpkg -l)
+$($CHROOTQEMUCMD -r $ROOTDIR dpkg -l)
 \`\`\`
 EOF

--- a/ev3dev-jessie/hooks/firstboot
+++ b/ev3dev-jessie/hooks/firstboot
@@ -1,1 +1,1 @@
-$CHROOTQEMUCMD $ROOTDIR update-rc.d firstboot start 99 S
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d firstboot start 99 S

--- a/ev3dev-jessie/hooks/fix-dbus
+++ b/ev3dev-jessie/hooks/fix-dbus
@@ -1,4 +1,4 @@
 # permissions for the "messagebus" group get messed up somehow, so we
 # reconfigure the dbus package to fix it.
 
-$CHROOTQEMUCMD $ROOTDIR dpkg-reconfigure dbus
+$CHROOTQEMUCMD -r $ROOTDIR dpkg-reconfigure dbus

--- a/ev3dev-jessie/hooks/root-passwd
+++ b/ev3dev-jessie/hooks/root-passwd
@@ -1,5 +1,5 @@
 # set root password
-$CHROOTQEMUCMD $ROOTDIR chpasswd << EOF
+$CHROOTQEMUCMD -r $ROOTDIR chpasswd << EOF
 root:r00tme
 EOF
 

--- a/ev3dev-jessie/hooks/systemd
+++ b/ev3dev-jessie/hooks/systemd
@@ -1,14 +1,14 @@
 # make sure serial-getty@.service does not try to use the serial ports because
 # we use them for other things
-$CHROOTQEMUCMD $ROOTDIR systemctl mask serial-getty@ttyS0.service
-$CHROOTQEMUCMD $ROOTDIR systemctl mask serial-getty@ttyS1.service
-$CHROOTQEMUCMD $ROOTDIR systemctl mask serial-getty@ttyS2.service
-$CHROOTQEMUCMD $ROOTDIR systemctl mask serial-getty@ttySU0.service
-$CHROOTQEMUCMD $ROOTDIR systemctl mask serial-getty@ttySU1.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl mask serial-getty@ttyS0.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl mask serial-getty@ttyS1.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl mask serial-getty@ttyS2.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl mask serial-getty@ttySU0.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl mask serial-getty@ttySU1.service
 
 # we want rndis enabled by default since most users are Windows users
-$CHROOTQEMUCMD $ROOTDIR systemctl enable rndis-gadget.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl enable rndis-gadget.service
 
 # use ssh.socket instead of ssh.service so that ssh sessions exit on shutdown/reboot
-$CHROOTQEMUCMD $ROOTDIR systemctl disable ssh.service
-$CHROOTQEMUCMD $ROOTDIR systemctl enable ssh.socket
+$CHROOTQEMUCMD -r $ROOTDIR systemctl disable ssh.service
+$CHROOTQEMUCMD -r $ROOTDIR systemctl enable ssh.socket

--- a/ev3dev-wheezy/hooks/console-setup
+++ b/ev3dev-wheezy/hooks/console-setup
@@ -1,4 +1,4 @@
 echo -e -n "\nFONT='Lat15-TomThumb4x6.psf.gz'" >> $ROOTDIR/etc/default/console-setup
-$CHROOTQEMUCMD $ROOTDIR setupcon --save-only
+$CHROOTQEMUCMD -r $ROOTDIR setupcon --save-only
 # keyboard-setup takes long time during boot, so disabling for now.
-$CHROOTQEMUCMD $ROOTDIR update-rc.d keyboard-setup disable
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d keyboard-setup disable

--- a/ev3dev-wheezy/hooks/create-changelog-template
+++ b/ev3dev-wheezy/hooks/create-changelog-template
@@ -22,6 +22,6 @@ Included Packages
 -----------------
 
 \`\`\`
-$($CHROOTQEMUCMD $ROOTDIR dpkg -l)
+$($CHROOTQEMUCMD -r $ROOTDIR dpkg -l)
 \`\`\`
 EOF

--- a/ev3dev-wheezy/hooks/firstboot
+++ b/ev3dev-wheezy/hooks/firstboot
@@ -46,4 +46,4 @@ echo "/dev/mapper/ev3devVG-swap none            swap   sw                       
 __END__
 
 chmod +x $ROOTDIR/etc/init.d/firstboot
-$CHROOTQEMUCMD $ROOTDIR update-rc.d firstboot start 99 S
+$CHROOTQEMUCMD -r $ROOTDIR update-rc.d firstboot start 99 S

--- a/ev3dev-wheezy/hooks/root_passwd
+++ b/ev3dev-wheezy/hooks/root_passwd
@@ -1,4 +1,4 @@
 # set root password
-$CHROOTQEMUCMD $ROOTDIR chpasswd << EOF
+$CHROOTQEMUCMD -r $ROOTDIR chpasswd << EOF
 root:r00tme
 EOF


### PR DESCRIPTION
 proot requires `-r` to be specified when passing in the root directory.
https://github.com/ev3dev/ev3dev/issues/209
