### PR TITLE
Introduce unshare-harder variant of brickstrap.sh.

### DIFF
--- a/brickstrap-unshare-harder.sh
+++ b/brickstrap-unshare-harder.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+HAVE_SU=$(which su)
+HAVE_SUDO=$(which sudo)
+SCRIPT_PATH=$(dirname $(readlink -f "$0"))
+USERNS_PRIV_SETTING=""
+
+bail_userns ()
+{
+    echo "Error: failed to enable unshare()"
+    exit 1
+}
+
+#
+# Helper to toggle kernel policy on whether or not to allow unshare() by normal users.
+# This requires elevated permissions, for acquiring them sudo and su are used if available.
+# If both are available, using sudo is preferred so the user invoking the script need not know the root password.
+#
+toggle_userns_setting ()
+{
+    if [ -n "$HAVE_SUDO" ]; then
+        echo "Using sudo ... may require password for '`whoami`'"
+        eval "echo '$1' | $HAVE_SUDO tee /proc/sys/kernel/unprivileged_userns_clone 1>/dev/null"
+    elif [ -n "$HAVE_SU" ]; then
+        echo "Using su ... may require password for 'root'"
+        eval "$HAVE_SU -c 'echo $1 > /proc/sys/kernel/unprivileged_userns_clone'"
+    else
+        echo "Error: need either sudo or su, neither appear to be available (on the PATH)."
+        return 1
+    fi
+}
+
+restore_userns_priv_setting ()
+{
+    # make sure to pass original exit code (brickstrap.sh) on
+    orig=$?
+    if [ -n "$USERNS_PRIV_SETTING" ]; then
+        echo "Restoring default policy on unshare() for normal users ..."
+        toggle_userns_setting "$USERNS_PRIV_SETTING" && return $orig
+    else
+        return $orig
+    fi
+}
+
+case "$1" in
+    # special case common brickstrap commands which do not require any userns fiddling
+    -h) ;;
+    *)
+        # brickstrap.sh requires at least one argument (command)
+        # it will therefore error out if it is missing before it requires userns fiddling
+        if [ -n "$1" -a -e /proc/sys/kernel/unprivileged_userns_clone ]; then
+            USERNS_PRIV_SETTING=$(cat /proc/sys/kernel/unprivileged_userns_clone)
+            if [ "$USERNS_PRIV_SETTING" = "0" ]; then
+                echo "Enabling normal user code to unshare() ..."
+                toggle_userns_setting 1 || bail_userns
+                trap restore_userns_priv_setting EXIT
+            fi
+        fi
+    ;;
+esac
+
+"$SCRIPT_PATH/brickstrap.sh" "$@"


### PR DESCRIPTION
This is Debian specific fallback version which will first prod the kernel into allowing ordinary users to unshare, as this is a necessary for user-unshare.pl on recent-ish Debian.
Any changes to original kernel settings are reverted on exit.
This workaround avoids having to run the entire brickstrap with sudo/su or to change the default unshare policy permanently.
Only the initial prodding and reverting need sudo/su privileges.

By request the unshare-harder variant was split off into a PR of its own, from #12
Continuing the comment thread:
 * The purpose of the unshare-harder variant is to avoid having to run the actual brickstrap command with elevated privileges, essentially extracting the privileged operations into well-defined, limited commands that do not touch files in the user's home directory.
 * This avoids running brickstrap as root even if unshare() is disabled for ordinary users by default on Debian. Running brickstrap with sudo or su would be quite a bad idea and rather ignore the entire raison d' être of brickstrap.
 * Using `sudo su` means that the user can simply input their 'normal' password instead of the password for root. This may be useful in scenarios where root isn't setup for login shells (as with e.g. Ubuntu by default) or they lack the root password. The downside is that the script requires sudo (in addition to su) which you may or may not find a gratuitous dep.  It's possible to make the exact choice (`sudo su` or plain `su`) configurable using a environment variable, of course... but even then the best default needs to be agreed upon.