### PR TITLE
Add support for a search path mechanism operating on a directory hierarchy.

### DIFF
--- a/brickstrap-paths.sh
+++ b/brickstrap-paths.sh
@@ -1,0 +1,445 @@
+#!/bin/bash
+#
+# This file is part of brickstrap.
+#
+# brickstrap - create a foreign architecture rootfs using kernel namespaces,
+#              multistrap, and qemu usermode emulation and create a disk image
+#              using libguestfs
+
+#
+# Note: this file is not meant to be executed, source it as a library of functions instead.
+# Variables used by the functions (other than stack) are namespaced using the 'BR_' prefix.
+# Function names are namespaced similarly, using the 'br_' prefix.
+#
+
+#
+# Helper function to check that path overlay variables are set to valid values if set.
+# These are meant to be called right after options parsing to check passed options/environment vars are sane.
+#
+#
+# Variables are considered 'valid' if unset (empty) or if at least one matching sub-hierarchy for the
+# variable can be found on the search path. Alternatively validation can be forced to report 'success' by
+# setting corresponding `BR_IGNORE_INVALID_*`.
+#
+
+function br_validate_project()
+{
+    if [ -z "$BR_PROJECT" -a -z "$BR_IGNORE_INVALID_PROJECT" ]; then
+        fail "Project required!"
+    else
+        [ -n "$BR_IGNORE_INVALID_PROJECT" -o -d "$BR_PROJECT" ] || \
+        fail "Not a valid project (no such directory): '$BR_PROJECT'"
+    fi
+}
+
+function br_validate_variant()
+{
+    [ -z "$BR_VARIANT" ] || \
+        [ -n "$BR_IGNORE_INVALID_VARIANT" ] || \
+        br_locate_directory "variant/$BR_VARIANT" -d >/dev/null || \
+        fail "Not a valid variant (no such directory): '$BR_VARIANT'"
+}
+
+function br_validate_board()
+{
+    [ -z "$BR_BOARD" ] || \
+        [ -n "$BR_IGNORE_INVALID_BOARD" ] || \
+        br_locate_directory "board/$BR_BOARD" >/dev/null || \
+        fail "Not a valid board (no such directory): '$BR_BOARD'"
+}
+
+function br_validate_arch()
+{
+    [ -z "$BR_ARCH" ] || \
+        [ -n "$BR_IGNORE_INVALID_ARCH" ] || \
+        br_locate_directory "arch/$BR_ARCH" >/dev/null || \
+        fail "Not a valid arch (no such directory): '$BR_ARCH'"
+}
+
+function br_validate_distro()
+{
+    [ -z "$BR_DISTRO" ] || \
+        [ -n "$BR_IGNORE_INVALID_DISTRO" ] || \
+        br_locate_directory "distro/$BR_DISTRO" >/dev/null || \
+        fail "Not a valid distro (no such directory): '$BR_DISTRO'"
+}
+
+#
+# Checks that the environment variables used for path overlays are sane.
+# The order in which various variables are checked is significant (for precise error reporting in case of simple typos).
+#
+function br_validate_search_path_vars()
+{
+    br_validate_project && br_validate_variant && br_validate_board && br_validate_arch && br_validate_distro
+}
+
+
+#
+# Helper functions for path lookup
+#
+
+
+#
+# Checks if a path should be 'accepted' and therefore returned by br_check_path.
+#
+# $1 the path to test
+# $2 a well-known path test or arbitrary callback (which will be invoked via eval and passed the path to test).
+#    special primitives 'true' and false' are recognised for the purpose of blanket inclusion/exclusion of paths.
+#
+function br_accept_path_if()
+{
+    case "$2" in
+    -d|-e|-f|-h|-L|-O|-G|-N|-s|-r|-w|-x) test "$2" "$1";; # known good path tests
+    true) return 0;; # permit a blanket override of 'true' to accept any path
+    false) return 1;; # permit a blanket override of 'false' to disallow any path
+    *)
+        # premit arbitrary path tests through a callback interface
+        # this can be used to reject files based on e.g. a static blacklist
+        if [ -n "$2" ]; then
+            eval "$2" "$1" || return 1
+        else
+            return 1
+        fi
+    ;;
+    esac
+}
+
+#
+# Checks a path against a path test, and if the test succeeds outputs the path.
+#
+# $1 path to test
+# $2 path test to perform
+# $3 optional: pass 'continue' to return with a status code of '255' instead of '0' on success.
+#    This mode may be useful in if-else logic to force continued evaluation of subsequent clauses.
+#
+function br_check_path()
+{
+    if [ $# -ge 2 ] && br_accept_path_if "$1" "$2"; then
+        if [ $# -eq 2 -o "$3" != "continue" ]; then
+            echo -n "$1"
+            return 0
+        else
+            echo "$1"
+            return 255
+        fi
+    else
+        return 1
+    fi
+}
+
+#
+# Find a distro-specific path.
+# Parameters:
+# $1 base path to find
+# $2 path test to confirm before accepting it (see accept_path_if)
+# $3 path prefix/directory on top of which the distro-specific hierarchy is layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
+#    This can be used to get all 'available' paths matching the base path and path test.
+#
+function br_find_distro_path()
+{
+    if [ $# -lt 3 -o -z "$BR_DISTRO" ] || [ ! -d "$3/distro/$BR_DISTRO" -a -z "$BR_IGNORE_INVALID_DISTRO" ]; then
+        return 1
+    elif br_check_path "$3/distro/$BR_DISTRO/$1" "$2" "${@:4:$#}"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Find an arch-specific path.
+# Parameters:
+# $1 base path to find
+# $2 path test to confirm before accepting it (see accept_path_if)
+# $3 path prefix/directory on top of which the arch-specific hierarchy is layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
+#    This can be used to get all 'available' paths matching the base path and path test.
+#
+function br_find_arch_path()
+{
+    # todo 'aliasing' for native arch?
+    if [ $# -lt 3 -o -z "$BR_ARCH" ] || [ ! -d "$3/arch/$BR_ARCH" -a -z "$BR_IGNORE_INVALID_ARCH" ]; then
+        return 1
+    elif br_find_distro_path "$1" "$2" "$3/arch/$BR_ARCH" "$4"; then
+        return 0
+    elif br_check_path "$3/arch/$BR_ARCH/$1" "$2" "$4"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Find a board-specific path.
+# Parameters:
+# $1 base path to find
+# $2 path test to confirm before accepting it (see accept_path_if)
+# $3 path prefix/directory on top of which the board-specific hierarchy is layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
+#    This can be used to get all 'available' paths matching the base path and path test.
+#
+function br_find_board_path ()
+{
+    if [ $# -lt 3 -o -z "$BR_BOARD" ] || [ ! -d "$3/board/$BR_BOARD" -a -z "$BR_IGNORE_INVALID_BOARD" ]; then
+        return 1
+    elif br_find_arch_path "$1" "$2" "$3/board/$BR_BOARD" "$4"; then
+        return 0
+    elif br_find_distro_path "$1" "$2" "$3/board/$BR_BOARD" "$4"; then
+        return 0
+    elif br_check_path "$3/board/$BR_BOARD/$1" "$2" "$4"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Find a variant-specific path.
+# Parameters:
+# $1 base path to find
+# $2 path test to confirm before accepting it (see accept_path_if)
+# $3 path prefix/directory on top of which the variant-specific hierarchy is layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
+#    This can be used to get all 'available' paths matching the base path and path test.
+#
+function br_find_variant_path()
+{
+    if [ $# -lt 3 -o -z "$BR_VARIANT" ] || [ ! -d "$3/variant/$BR_VARIANT" -a -z "$BR_IGNORE_INVALID_VARIANT" ]; then
+        return 1
+    elif br_find_board_path "$1" "$2" "$3/variant/$BR_VARIANT" "$4"; then
+        return 0
+    elif br_find_arch_path "$1" "$2" "$3/variant/$BR_VARIANT" "$4"; then
+        return 0
+    elif br_find_distro_path "$1" "$2" "$3/variant/$BR_VARIANT" "$4"; then
+        return 0
+    elif br_check_path "$3/variant/$BR_VARIANT/$1" "$2" "$4"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Find a path in the project.
+# Parameters:
+# $1 base path to find
+# $2 path test to confirm before accepting it (see accept_path_if)
+# $3 optional: pass 'continue' to continue search for acceptable paths once one has been found.
+#    This can be used to get all 'available' paths matching the base path and path test.
+#
+function br_find_path()
+{
+    if [ $# -lt 2 -o -z "$BR_PROJECT" ]; then
+        return 1
+    elif br_find_variant_path "$1" "$2" "$BR_PROJECT" "$3"; then
+        return 0
+    elif br_find_board_path "$1" "$2" "$BR_PROJECT" "$3"; then
+        return 0
+    elif br_find_arch_path "$1" "$2" "$BR_PROJECT" "$3"; then
+        return 0
+    elif br_find_distro_path "$1" "$2" "$BR_PROJECT" "$3"; then
+        return 0
+    elif br_check_path "$BR_PROJECT/$1" "$2" "$3"; then
+        return 0
+    elif [ $? -eq 255 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Functions to look up a base path matching a given path test.
+# This is a more convenient interface around br_find_path.
+# Usage var=$(br_locate_path query -r) || echo "error" # checks 'query' resolves to a read-able file
+#
+# $1
+#
+function br_locate_path()
+{
+    [ $# -ge 1 ] && if [ -n "$2" ]; then
+        br_find_path "$1" "$2"
+    else
+        br_find_path "$1" -e
+    fi
+}
+
+function br_locate_directory()
+{
+    [ $# -eq 1 ] && br_find_path "$1" -d
+}
+
+#
+# Functions to generate a list of paths matching a given base path and path test.
+# This is a more convenient interface around br_find_path.
+#
+# The paths may be consumed by piping output into a 'while IFS='' read -r line' block or by using the
+# callback interface of br_consume_path_list* functions.
+#
+# $1 base path to find
+# $2 optional: path test or the string 'reverse' if $3 isn't passed.
+# $3 optional: pass 'reverse' to reverse the order of the paths in output.
+#
+function br_list_paths()
+{
+    [ $# -ge 1 ] && if [ $# -gt 2 -a -n "$3" -a "$3" = "reverse" ]; then
+        br_find_path "$1" "$2" "continue" | tac
+    elif [ $# -eq 2 -a -n "$2" -a "$2" = "reverse" ]; then
+        br_find_path "$1" -e "continue" | tac
+    elif [ $# -eq 2 ]; then
+        br_find_path "$1" "$2" "continue"
+    else
+        br_find_path "$1" -e "continue"
+    fi
+}
+
+#
+# Convenience version of br_list_paths which uses a fixed path test of -d (directories)
+#
+# $1 base path to find
+# $2 optional: pass 'reverse' to reverse the order of the paths in output
+#
+function br_list_directories()
+{
+    [ $# -ge 1 ] && br_list_paths "$1" -d "$2"
+}
+
+#
+# Callback interface to consume path lists generated by br_list_*()
+#
+# br_list_* path ...optional_list_args | br_consume_path_list* call_back_name optional_call_back_args...
+#
+# The calling convention is:
+#
+# The callback argument is eval'ed
+# The callback is passed the current file being consumed (BR_PATHS_CUR_FILE) as last argument.
+# Optional callback args are passed on.
+#
+# No special handling for spaces-in-arguments is performed, so users of br_consume_path_list* functions
+# must make sure any spaces in arguments are properply escaped.
+#
+# Return code of the callback is captured (if it returns a non-zero status code).
+# If previous invocations of the callback failed, the last captured error code will be in BR_PATHS_CB_RETURNCODE
+# If any invocation of the callback fails (i.e. returned non-zero status code) or if another error occurs,
+# the br_consume_path_list*() function will return with a non-zero return code.
+#
+# This means something like this will print directories found using a given printf format:
+#
+# br_list_directories query | br_consume_path_list printf 'found: %s\\n' || echo "error"
+#
+
+function br_consume_path_list()
+{
+    BR_PATHS_CB_RETURNCODE=0
+    [ $# -ge 1 -a -n "$1" ] && while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
+        eval "$@ \"$BR_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
+    done && return "$BR_PATHS_CB_RETURNCODE"
+}
+
+#
+# Version of br_consume_path_list which shifts arguments up by one.
+# The first argument ($1) should be the same as the one passed to the br_list_* function that was used to generate the
+# input to br_consume_path_list_iterate_directories.
+# Example usage:
+# br_list_directories "$query" | br_consume_path_list_iterate_directories "$query" echo
+#
+function br_consume_path_list_iterate_directories()
+{
+    BR_PATHS_CB_RETURNCODE=0
+    [ $# -ge 2 -a -n "$1" -a -n "$2" ] && while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
+        for BR_PATHS_CUR_FILE in "$BR_PATHS_CUR_FILE/"*; do
+            if [ "$(br_locate_path "$1/`basename $BR_PATHS_CUR_FILE`")" = "$BR_PATHS_CUR_FILE" ]; then
+                eval "${@:2:$#} \"$BR_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
+            fi
+        done
+    done && return "$BR_PATHS_CB_RETURNCODE"
+}
+
+#
+# Debug tools: list paths/search path information.
+# Aside from command line argument parsing these are 'complete' sub-programs and may be wired up to respective commands directly.
+#
+
+function br_print_path()
+{
+    br_validate_search_path_vars && if [ -n "$1" ]; then
+        info "Locate: '$1'"
+        if BR_PATHS_CUR_FILE=$(br_locate_path "$1") && [ -n "$BR_PATHS_CUR_FILE" ]; then
+            info "Found: '$BR_PATHS_CUR_FILE'"
+            return 0
+        else
+            info "Not found."
+            return 2
+        fi
+    else
+        fail "Path required!"
+    fi
+}
+
+function br_print_all_paths()
+{
+    br_validate_search_path_vars && if [ -n "$1" ]; then
+        BR_path_prio_count=0
+        BR_PATHS_CB_RETURNCODE=""
+        info "Find: '$1'"
+        br_list_paths "$1" -e "$2" | br_consume_path_list 'br_path_cb() { ((BR_path_prio_count++)); info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+
+        if [ $? -eq 0 ]; then
+            return 0
+        elif [ -z "$BR_PATHS_CB_RETURNCODE" ]; then
+            info "Not found."
+            return 2
+        else
+            fail "Error occured"
+        fi
+    else
+        fail "Path required!"
+    fi
+}
+
+function br_print_all_dir_listing()
+{
+    br_validate_project && if [ -n "$1" ]; then
+        BR_path_prio_count=0
+        BR_PATHS_CB_RETURNCODE=""
+        info "List directories: $1"
+        br_list_directories "$1" "$2" | br_consume_path_list_iterate_directories "$1" 'br_path_cb() { ((BR_path_prio_count++)); info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+
+        if [ $? -eq 0 ]; then
+            return 0
+        elif [ -z "$BR_PATHS_CB_RETURNCODE" ]; then
+            info "Nothing found."
+            return 2
+        else
+            fail "Error occured"
+        fi
+    else
+        fail "Path required!"
+    fi
+}
+
+function br_print_search_paths()
+{
+    if [ -n "$BR_PROJECT" ]; then
+        BR_path_prio_count=0
+        BR_PATHS_CB_RETURNCODE=""
+        if [ ! -d "$BR_PROJECT" ]; then
+            warn "Invalid project (not a directory): $BR_PROJECT"
+            warn "Without a valid project directory as anchor, search path is purely hypothetical and will not actually work."
+        fi
+        info "List search path:"
+        br_list_paths "" 'true' "$1" | br_consume_path_list 'br_path_cb() { ((BR_path_prio_count++)); info "Path[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+
+        if [ $? -eq 0 ]; then
+            return 0
+        elif [ -z "$BR_PATHS_CB_RETURNCODE" ]; then
+            info "Empty search path!"
+            return 2
+        else
+            fail "Error occured"
+        fi
+    else
+        fail "Project required!"
+    fi
+}

--- a/brickstrap-paths.sh
+++ b/brickstrap-paths.sh
@@ -5,21 +5,26 @@
 # brickstrap - create a foreign architecture rootfs using kernel namespaces,
 #              multistrap, and qemu usermode emulation and create a disk image
 #              using libguestfs
-
 #
-# Note: this file is not meant to be executed, source it as a library of functions instead.
-# Variables used by the functions (other than stack) are namespaced using the 'BR_' prefix.
-# Function names are namespaced similarly, using the 'br_' prefix.
+# Copyright (C) 2016 Johan Ouwerkerk <jm.ouwerkerk@gmail.com>
 #
 
 #
-# Helper function to check that path overlay variables are set to valid values if set.
-# These are meant to be called right after options parsing to check passed options/environment vars are sane.
+# Note: this file is not meant to be executed, source it as a library of
+# functions instead. Variables used by the functions (other than stack) are
+# namespaced using the 'BR_' prefix. Function names are namespaced similarly,
+# using the 'br_' prefix.
 #
+
 #
-# Variables are considered 'valid' if unset (empty) or if at least one matching sub-hierarchy for the
-# variable can be found on the search path. Alternatively validation can be forced to report 'success' by
-# setting corresponding `BR_IGNORE_INVALID_*`.
+# Helper functions to check that path overlay variables are set to valid values
+# if set. These are meant to be called right after options parsing to check
+# passed options/environment vars are sane.
+#
+# Variables are considered 'valid' if unset (empty) or if at least one matching
+# sub-hierarchy for the variable can be found on the search path. Alternatively
+# validation can be forced to report 'success' by setting the corresponding
+# 'BR_IGNORE_INVALID_*' variable.
 #
 
 function br_validate_project()
@@ -66,11 +71,13 @@ function br_validate_distro()
 
 #
 # Checks that the environment variables used for path overlays are sane.
-# The order in which various variables are checked is significant (for precise error reporting in case of simple typos).
+# The order in which various variables are checked is significant (for precise
+# error reporting in case of simple typos).
 #
 function br_validate_search_path_vars()
 {
-    br_validate_project && br_validate_variant && br_validate_board && br_validate_arch && br_validate_distro
+    br_validate_project && br_validate_variant && br_validate_board && \
+        br_validate_arch && br_validate_distro
 }
 
 
@@ -80,18 +87,22 @@ function br_validate_search_path_vars()
 
 
 #
-# Checks if a path should be 'accepted' and therefore returned by br_check_path.
+# Checks if a path should be 'accepted' and therefore returned by br_check_path
 #
 # $1 the path to test
-# $2 a well-known path test or arbitrary callback (which will be invoked via eval and passed the path to test).
-#    special primitives 'true' and false' are recognised for the purpose of blanket inclusion/exclusion of paths.
+# $2 a well-known path test or arbitrary callback (which will be invoked via
+#    eval and passed the path to test). Special primitives 'true' and false'
+#    are recognised for the purpose of blanket inclusion/exclusion of paths.
 #
 function br_accept_path_if()
 {
     case "$2" in
-    -d|-e|-f|-h|-L|-O|-G|-N|-s|-r|-w|-x) test "$2" "$1";; # known good path tests
-    true) return 0;; # permit a blanket override of 'true' to accept any path
-    false) return 1;; # permit a blanket override of 'false' to disallow any path
+    # known good path tests
+    -d|-e|-f|-h|-L|-O|-G|-N|-s|-r|-w|-x) test "$2" "$1";;
+    # permit a blanket override of 'true' to accept any path
+    true) return 0;;
+    # permit a blanket override of 'false' to disallow any path
+    false) return 1;;
     *)
         # premit arbitrary path tests through a callback interface
         # this can be used to reject files based on e.g. a static blacklist
@@ -109,8 +120,9 @@ function br_accept_path_if()
 #
 # $1 path to test
 # $2 path test to perform
-# $3 optional: pass 'continue' to return with a status code of '255' instead of '0' on success.
-#    This mode may be useful in if-else logic to force continued evaluation of subsequent clauses.
+# $3 optional: pass 'continue' to return with a status code of '255' instead of
+#    '0' on success. This mode may be useful in if-else logic to force
+#    continued evaluation of subsequent clauses.
 #
 function br_check_path()
 {
@@ -132,13 +144,16 @@ function br_check_path()
 # Parameters:
 # $1 base path to find
 # $2 path test to confirm before accepting it (see accept_path_if)
-# $3 path prefix/directory on top of which the distro-specific hierarchy is layered.
-# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
-#    This can be used to get all 'available' paths matching the base path and path test.
+# $3 path prefix/directory on top of which the distro-specific hierarchy is
+#    layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one
+#    has been found. This can be used to get all 'available' paths matching the
+#    base path and path test.
 #
 function br_find_distro_path()
 {
-    if [ $# -lt 3 -o -z "$BR_DISTRO" ] || [ ! -d "$3/distro/$BR_DISTRO" -a -z "$BR_IGNORE_INVALID_DISTRO" ]; then
+    if [ $# -lt 3 -o -z "$BR_DISTRO" ] || \
+        [ ! -d "$3/distro/$BR_DISTRO" -a -z "$BR_IGNORE_INVALID_DISTRO" ]; then
         return 1
     elif br_check_path "$3/distro/$BR_DISTRO/$1" "$2" "${@:4:$#}"; then
         return 0
@@ -152,14 +167,17 @@ function br_find_distro_path()
 # Parameters:
 # $1 base path to find
 # $2 path test to confirm before accepting it (see accept_path_if)
-# $3 path prefix/directory on top of which the arch-specific hierarchy is layered.
-# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
-#    This can be used to get all 'available' paths matching the base path and path test.
+# $3 path prefix/directory on top of which the arch-specific hierarchy is
+#    layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one
+#    has been found. This can be used to get all 'available' paths matching the
+#    base path and path test.
 #
 function br_find_arch_path()
 {
     # todo 'aliasing' for native arch?
-    if [ $# -lt 3 -o -z "$BR_ARCH" ] || [ ! -d "$3/arch/$BR_ARCH" -a -z "$BR_IGNORE_INVALID_ARCH" ]; then
+    if [ $# -lt 3 -o -z "$BR_ARCH" ] || \
+        [ ! -d "$3/arch/$BR_ARCH" -a -z "$BR_IGNORE_INVALID_ARCH" ]; then
         return 1
     elif br_find_distro_path "$1" "$2" "$3/arch/$BR_ARCH" "$4"; then
         return 0
@@ -175,13 +193,16 @@ function br_find_arch_path()
 # Parameters:
 # $1 base path to find
 # $2 path test to confirm before accepting it (see accept_path_if)
-# $3 path prefix/directory on top of which the board-specific hierarchy is layered.
-# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
-#    This can be used to get all 'available' paths matching the base path and path test.
+# $3 path prefix/directory on top of which the board-specific hierarchy is
+#    layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one
+#    has been found. This can be used to get all 'available' paths matching the
+#    base path and path test.
 #
 function br_find_board_path ()
 {
-    if [ $# -lt 3 -o -z "$BR_BOARD" ] || [ ! -d "$3/board/$BR_BOARD" -a -z "$BR_IGNORE_INVALID_BOARD" ]; then
+    if [ $# -lt 3 -o -z "$BR_BOARD" ] || \
+        [ ! -d "$3/board/$BR_BOARD" -a -z "$BR_IGNORE_INVALID_BOARD" ]; then
         return 1
     elif br_find_arch_path "$1" "$2" "$3/board/$BR_BOARD" "$4"; then
         return 0
@@ -199,13 +220,17 @@ function br_find_board_path ()
 # Parameters:
 # $1 base path to find
 # $2 path test to confirm before accepting it (see accept_path_if)
-# $3 path prefix/directory on top of which the variant-specific hierarchy is layered.
-# $4 optional: pass 'continue' to continue search for acceptable paths once one has been found.
-#    This can be used to get all 'available' paths matching the base path and path test.
+# $3 path prefix/directory on top of which the variant-specific hierarchy is
+#    layered.
+# $4 optional: pass 'continue' to continue search for acceptable paths once one
+#    has been found. This can be used to get all 'available' paths matching the
+#    base path and path test.
 #
 function br_find_variant_path()
 {
-    if [ $# -lt 3 -o -z "$BR_VARIANT" ] || [ ! -d "$3/variant/$BR_VARIANT" -a -z "$BR_IGNORE_INVALID_VARIANT" ]; then
+    if [ $# -lt 3 -o -z "$BR_VARIANT" ] || \
+        [ ! -d "$3/variant/$BR_VARIANT" -a -z "$BR_IGNORE_INVALID_VARIANT" ]
+    then
         return 1
     elif br_find_board_path "$1" "$2" "$3/variant/$BR_VARIANT" "$4"; then
         return 0
@@ -225,8 +250,9 @@ function br_find_variant_path()
 # Parameters:
 # $1 base path to find
 # $2 path test to confirm before accepting it (see accept_path_if)
-# $3 optional: pass 'continue' to continue search for acceptable paths once one has been found.
-#    This can be used to get all 'available' paths matching the base path and path test.
+# $3 optional: pass 'continue' to continue search for acceptable paths once one
+#    has been found. This can be used to get all 'available' paths matching the
+#    base path and path test.
 #
 function br_find_path()
 {
@@ -250,11 +276,14 @@ function br_find_path()
 }
 
 #
-# Functions to look up a base path matching a given path test.
-# This is a more convenient interface around br_find_path.
-# Usage var=$(br_locate_path query -r) || echo "error" # checks 'query' resolves to a read-able file
+# Functions to look up a base path matching a given path test. This is a more
+# convenient interface around br_find_path. Usage:
 #
-# $1
+#  # checks 'query' resolves to a read-able file
+#  var=$(br_locate_path query -r) || echo "error"
+#
+# $1 base path to find
+# $2 optional: path test (if not passed, '-e' is used by default)
 #
 function br_locate_path()
 {
@@ -271,14 +300,15 @@ function br_locate_directory()
 }
 
 #
-# Functions to generate a list of paths matching a given base path and path test.
-# This is a more convenient interface around br_find_path.
+# Functions to generate a list of paths matching a given base path and path
+# test. This is a more convenient interface around br_find_path.
 #
-# The paths may be consumed by piping output into a 'while IFS='' read -r line' block or by using the
-# callback interface of br_consume_path_list* functions.
+# The paths may be consumed by piping output into a 'while IFS='' read -r line'
+# block or by using the callback interface of br_consume_path_list* functions.
 #
 # $1 base path to find
-# $2 optional: path test or the string 'reverse' if $3 isn't passed.
+# $2 optional: path test. Alternatively the string 'reverse' may be passed if
+#    $3 isn't used, to reverse order of output.
 # $3 optional: pass 'reverse' to reverse the order of the paths in output.
 #
 function br_list_paths()
@@ -295,7 +325,7 @@ function br_list_paths()
 }
 
 #
-# Convenience version of br_list_paths which uses a fixed path test of -d (directories)
+# Convenience version of br_list_paths which uses a fixed path test of '-d'.
 #
 # $1 base path to find
 # $2 optional: pass 'reverse' to reverse the order of the paths in output
@@ -306,51 +336,62 @@ function br_list_directories()
 }
 
 #
-# Callback interface to consume path lists generated by br_list_*()
+# Callback interface to consume path lists generated by br_list_*(). Usage:
 #
-# br_list_* path ...optional_list_args | br_consume_path_list* call_back_name optional_call_back_args...
+# br_list_* path ...optional_list_args | \
+#     br_consume_path_list* call_back_name optional_call_back_args...
 #
 # The calling convention is:
 #
-# The callback argument is eval'ed
-# The callback is passed the current file being consumed (BR_PATHS_CUR_FILE) as last argument.
-# Optional callback args are passed on.
+# The callback argument is eval'ed; the callback is passed the current file
+# being consumed (BR_PATHS_CUR_FILE) as last argument. Optional callback args
+# are passed on.
 #
-# No special handling for spaces-in-arguments is performed, so users of br_consume_path_list* functions
-# must make sure any spaces in arguments are properply escaped.
+# No special handling for spaces-in-arguments is performed, so users of
+# br_consume_path_list* functions must make sure any spaces in arguments are
+# properply escaped.
 #
-# Return code of the callback is captured (if it returns a non-zero status code).
-# If previous invocations of the callback failed, the last captured error code will be in BR_PATHS_CB_RETURNCODE
-# If any invocation of the callback fails (i.e. returned non-zero status code) or if another error occurs,
-# the br_consume_path_list*() function will return with a non-zero return code.
+# Return code of the callback is captured (if non-zero). If previous
+# invocations of the callback failed, the last captured error code will be
+# saved in BR_PATHS_CB_RETURNCODE. If any invocations of the callback fail
+# (i.e. returned non-zero status code) or if another error occurs, the
+# br_consume_path_list*() function will return with a non-zero return code.
 #
-# This means something like this will print directories found using a given printf format:
+# This means something like this will print directories found using a given
+# 'printf' format:
 #
-# br_list_directories query | br_consume_path_list printf 'found: %s\\n' || echo "error"
+# br_list_directories query | \
+#    br_consume_path_list printf 'found: %s\\n' || echo "error"
 #
 
 function br_consume_path_list()
 {
     BR_PATHS_CB_RETURNCODE=0
-    [ $# -ge 1 -a -n "$1" ] && while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
+    [ $# -ge 1 -a -n "$1" ] && \
+    while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
         eval "$@ \"$BR_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
     done && return "$BR_PATHS_CB_RETURNCODE"
 }
 
 #
 # Version of br_consume_path_list which shifts arguments up by one.
-# The first argument ($1) should be the same as the one passed to the br_list_* function that was used to generate the
-# input to br_consume_path_list_iterate_directories.
-# Example usage:
-# br_list_directories "$query" | br_consume_path_list_iterate_directories "$query" echo
+# The first argument ($1) should be the same as the one passed to the br_list_*
+# function that was used to generate the input to
+# br_consume_path_list_iterate_directories. Example usage:
+#
+# br_list_directories "$query" | \
+#    br_consume_path_list_iterate_directories "$query" echo
 #
 function br_consume_path_list_iterate_directories()
 {
     BR_PATHS_CB_RETURNCODE=0
-    [ $# -ge 2 -a -n "$1" -a -n "$2" ] && while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
+    [ $# -ge 2 -a -n "$1" -a -n "$2" ] && \
+    while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
         for BR_PATHS_CUR_FILE in "$BR_PATHS_CUR_FILE/"*; do
-            if [ "$(br_locate_path "$1/`basename $BR_PATHS_CUR_FILE`")" = "$BR_PATHS_CUR_FILE" ]; then
-                eval "${@:2:$#} \"$BR_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
+            if [ "$(br_locate_path "$1/`basename $BR_PATHS_CUR_FILE`")" = \
+                "$BR_PATHS_CUR_FILE" ]; then
+                eval "${@:2:$#} \"$BR_PATHS_CUR_FILE\"" || \
+                    BR_PATHS_CB_RETURNCODE=$?
             fi
         done
     done && return "$BR_PATHS_CB_RETURNCODE"
@@ -358,14 +399,16 @@ function br_consume_path_list_iterate_directories()
 
 #
 # Debug tools: list paths/search path information.
-# Aside from command line argument parsing these are 'complete' sub-programs and may be wired up to respective commands directly.
+# Aside from command line argument parsing these are 'complete' sub-programs
+# and may be wired up to respective commands directly.
 #
 
 function br_print_path()
 {
     br_validate_search_path_vars && if [ -n "$1" ]; then
         info "Locate: '$1'"
-        if BR_PATHS_CUR_FILE=$(br_locate_path "$1") && [ -n "$BR_PATHS_CUR_FILE" ]; then
+        if BR_PATHS_CUR_FILE=$(br_locate_path "$1") && \
+            [ -n "$BR_PATHS_CUR_FILE" ]; then
             info "Found: '$BR_PATHS_CUR_FILE'"
             return 0
         else
@@ -383,7 +426,9 @@ function br_print_all_paths()
         BR_path_prio_count=0
         BR_PATHS_CB_RETURNCODE=""
         info "Find: '$1'"
-        br_list_paths "$1" -e "$2" | br_consume_path_list 'br_path_cb() { ((BR_path_prio_count++)); info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+        br_list_paths "$1" -e "$2" | br_consume_path_list \
+            'br_path_cb() { ((BR_path_prio_count++)); \
+            info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0
@@ -404,7 +449,10 @@ function br_print_all_dir_listing()
         BR_path_prio_count=0
         BR_PATHS_CB_RETURNCODE=""
         info "List directories: $1"
-        br_list_directories "$1" "$2" | br_consume_path_list_iterate_directories "$1" 'br_path_cb() { ((BR_path_prio_count++)); info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+        br_list_directories "$1" "$2" | \
+            br_consume_path_list_iterate_directories "$1" \
+            'br_path_cb() { ((BR_path_prio_count++)); \
+            info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0
@@ -426,10 +474,13 @@ function br_print_search_paths()
         BR_PATHS_CB_RETURNCODE=""
         if [ ! -d "$BR_PROJECT" ]; then
             warn "Invalid project (not a directory): $BR_PROJECT"
-            warn "Without a valid project directory as anchor, search path is purely hypothetical and will not actually work."
+            warn \
+            "The search path will not work without a valid project directory."
         fi
         info "List search path:"
-        br_list_paths "" 'true' "$1" | br_consume_path_list 'br_path_cb() { ((BR_path_prio_count++)); info "Path[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+        br_list_paths "" 'true' "$1" | br_consume_path_list \
+        'br_path_cb() { ((BR_path_prio_count++)); \
+        info "Path[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0

--- a/brickstrap-paths.sh
+++ b/brickstrap-paths.sh
@@ -12,8 +12,9 @@
 #
 # Note: this file is not meant to be executed, source it as a library of
 # functions instead. Variables used by the functions (other than stack) are
-# namespaced using the 'BR_' prefix. Function names are namespaced similarly,
-# using the 'br_' prefix.
+# namespaced using the 'BR_' or 'BRP_' prefixes. Function names are namespaced
+# similarly, using the 'br_' and 'brp_' prefixes. See docs/namespacing.md for
+# more information on namespacing in brickstrap.
 #
 
 #
@@ -27,7 +28,7 @@
 # 'BR_IGNORE_INVALID_*' variable.
 #
 
-function br_validate_project()
+function brp_validate_project()
 {
     if [ -z "$BR_PROJECT" -a -z "$BR_IGNORE_INVALID_PROJECT" ]; then
         fail "Project required!"
@@ -37,7 +38,7 @@ function br_validate_project()
     fi
 }
 
-function br_validate_variant()
+function brp_validate_variant()
 {
     [ -z "$BR_VARIANT" ] || \
         [ -n "$BR_IGNORE_INVALID_VARIANT" ] || \
@@ -45,7 +46,7 @@ function br_validate_variant()
         fail "Not a valid variant (no such directory): '$BR_VARIANT'"
 }
 
-function br_validate_board()
+function brp_validate_board()
 {
     [ -z "$BR_BOARD" ] || \
         [ -n "$BR_IGNORE_INVALID_BOARD" ] || \
@@ -53,7 +54,7 @@ function br_validate_board()
         fail "Not a valid board (no such directory): '$BR_BOARD'"
 }
 
-function br_validate_arch()
+function brp_validate_arch()
 {
     [ -z "$BR_ARCH" ] || \
         [ -n "$BR_IGNORE_INVALID_ARCH" ] || \
@@ -61,7 +62,7 @@ function br_validate_arch()
         fail "Not a valid arch (no such directory): '$BR_ARCH'"
 }
 
-function br_validate_distro()
+function brp_validate_distro()
 {
     [ -z "$BR_DISTRO" ] || \
         [ -n "$BR_IGNORE_INVALID_DISTRO" ] || \
@@ -74,7 +75,7 @@ function br_validate_distro()
 # The order in which various variables are checked is significant (for precise
 # error reporting in case of simple typos).
 #
-function br_validate_search_path_vars()
+function brp_validate_search_path_vars()
 {
     br_validate_project && br_validate_variant && br_validate_board && \
         br_validate_arch && br_validate_distro
@@ -94,7 +95,7 @@ function br_validate_search_path_vars()
 #    eval and passed the path to test). Special primitives 'true' and false'
 #    are recognised for the purpose of blanket inclusion/exclusion of paths.
 #
-function br_accept_path_if()
+function brp_accept_path_if()
 {
     case "$2" in
     # known good path tests
@@ -124,7 +125,7 @@ function br_accept_path_if()
 #    '0' on success. This mode may be useful in if-else logic to force
 #    continued evaluation of subsequent clauses.
 #
-function br_check_path()
+function brp_check_path()
 {
     if [ $# -ge 2 ] && br_accept_path_if "$1" "$2"; then
         if [ $# -eq 2 -o "$3" != "continue" ]; then
@@ -150,7 +151,7 @@ function br_check_path()
 #    has been found. This can be used to get all 'available' paths matching the
 #    base path and path test.
 #
-function br_find_distro_path()
+function brp_find_distro_path()
 {
     if [ $# -lt 3 -o -z "$BR_DISTRO" ] || \
         [ ! -d "$3/distro/$BR_DISTRO" -a -z "$BR_IGNORE_INVALID_DISTRO" ]; then
@@ -173,7 +174,7 @@ function br_find_distro_path()
 #    has been found. This can be used to get all 'available' paths matching the
 #    base path and path test.
 #
-function br_find_arch_path()
+function brp_find_arch_path()
 {
     # todo 'aliasing' for native arch?
     if [ $# -lt 3 -o -z "$BR_ARCH" ] || \
@@ -199,7 +200,7 @@ function br_find_arch_path()
 #    has been found. This can be used to get all 'available' paths matching the
 #    base path and path test.
 #
-function br_find_board_path ()
+function brp_find_board_path ()
 {
     if [ $# -lt 3 -o -z "$BR_BOARD" ] || \
         [ ! -d "$3/board/$BR_BOARD" -a -z "$BR_IGNORE_INVALID_BOARD" ]; then
@@ -226,7 +227,7 @@ function br_find_board_path ()
 #    has been found. This can be used to get all 'available' paths matching the
 #    base path and path test.
 #
-function br_find_variant_path()
+function brp_find_variant_path()
 {
     if [ $# -lt 3 -o -z "$BR_VARIANT" ] || \
         [ ! -d "$3/variant/$BR_VARIANT" -a -z "$BR_IGNORE_INVALID_VARIANT" ]
@@ -254,7 +255,7 @@ function br_find_variant_path()
 #    has been found. This can be used to get all 'available' paths matching the
 #    base path and path test.
 #
-function br_find_path()
+function brp_find_path()
 {
     if [ $# -lt 2 -o -z "$BR_PROJECT" ]; then
         return 1
@@ -368,8 +369,8 @@ function br_consume_path_list()
 {
     BR_PATHS_CB_RETURNCODE=0
     [ $# -ge 1 -a -n "$1" ] && \
-    while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
-        eval "$@ \"$BR_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
+    while IFS='' read -r BRP_PATHS_CUR_FILE || [ -n "$BRP_PATHS_CUR_FILE" ]; do
+        eval "$@ \"$BRP_PATHS_CUR_FILE\"" || BR_PATHS_CB_RETURNCODE=$?
     done && return "$BR_PATHS_CB_RETURNCODE"
 }
 
@@ -386,11 +387,11 @@ function br_consume_path_list_iterate_directories()
 {
     BR_PATHS_CB_RETURNCODE=0
     [ $# -ge 2 -a -n "$1" -a -n "$2" ] && \
-    while IFS='' read -r BR_PATHS_CUR_FILE || [ -n "$BR_PATHS_CUR_FILE" ]; do
-        for BR_PATHS_CUR_FILE in "$BR_PATHS_CUR_FILE/"*; do
-            if [ "$(br_locate_path "$1/`basename $BR_PATHS_CUR_FILE`")" = \
-                "$BR_PATHS_CUR_FILE" ]; then
-                eval "${@:2:$#} \"$BR_PATHS_CUR_FILE\"" || \
+    while IFS='' read -r BRP_PATHS_CUR_FILE || [ -n "$BRP_PATHS_CUR_FILE" ]; do
+        for BRP_PATHS_CUR_FILE in "$BRP_PATHS_CUR_FILE/"*; do
+            if [ "$(br_locate_path "$1/`basename $BRP_PATHS_CUR_FILE`")" = \
+                "$BRP_PATHS_CUR_FILE" ]; then
+                eval "${@:2:$#} \"$BRP_PATHS_CUR_FILE\"" || \
                     BR_PATHS_CB_RETURNCODE=$?
             fi
         done
@@ -403,13 +404,13 @@ function br_consume_path_list_iterate_directories()
 # and may be wired up to respective commands directly.
 #
 
-function br_print_path()
+function brp_print_path()
 {
     br_validate_search_path_vars && if [ -n "$1" ]; then
         info "Locate: '$1'"
-        if BR_PATHS_CUR_FILE=$(br_locate_path "$1") && \
-            [ -n "$BR_PATHS_CUR_FILE" ]; then
-            info "Found: '$BR_PATHS_CUR_FILE'"
+        if BRP_PATHS_CUR_FILE=$(br_locate_path "$1") && \
+            [ -n "$BRP_PATHS_CUR_FILE" ]; then
+            info "Found: '$BRP_PATHS_CUR_FILE'"
             return 0
         else
             info "Not found."
@@ -420,15 +421,15 @@ function br_print_path()
     fi
 }
 
-function br_print_all_paths()
+function brp_print_all_paths()
 {
     br_validate_search_path_vars && if [ -n "$1" ]; then
-        BR_path_prio_count=0
+        BRP_path_prio_count=0
         BR_PATHS_CB_RETURNCODE=""
         info "Find: '$1'"
         br_list_paths "$1" -e "$2" | br_consume_path_list \
-            'br_path_cb() { ((BR_path_prio_count++)); \
-            info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+            'br_path_cb() { ((BRP_path_prio_count++)); \
+            info "[$BRP_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0
@@ -443,16 +444,16 @@ function br_print_all_paths()
     fi
 }
 
-function br_print_all_dir_listing()
+function brp_print_all_dir_listing()
 {
     br_validate_project && if [ -n "$1" ]; then
-        BR_path_prio_count=0
+        BRP_path_prio_count=0
         BR_PATHS_CB_RETURNCODE=""
         info "List directories: $1"
         br_list_directories "$1" "$2" | \
             br_consume_path_list_iterate_directories "$1" \
-            'br_path_cb() { ((BR_path_prio_count++)); \
-            info "[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+            'br_path_cb() { ((BRP_path_prio_count++)); \
+            info "[$BRP_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0
@@ -467,10 +468,10 @@ function br_print_all_dir_listing()
     fi
 }
 
-function br_print_search_paths()
+function brp_print_search_paths()
 {
     if [ -n "$BR_PROJECT" ]; then
-        BR_path_prio_count=0
+        BRP_path_prio_count=0
         BR_PATHS_CB_RETURNCODE=""
         if [ ! -d "$BR_PROJECT" ]; then
             warn "Invalid project (not a directory): $BR_PROJECT"
@@ -479,8 +480,8 @@ function br_print_search_paths()
         fi
         info "List search path:"
         br_list_paths "" 'true' "$1" | br_consume_path_list \
-        'br_path_cb() { ((BR_path_prio_count++)); \
-        info "Path[$BR_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
+        'br_path_cb() { ((BRP_path_prio_count++)); \
+        info "Path[$BRP_path_prio_count]: '"'\$1'"'"; }; br_path_cb'
 
         if [ $? -eq 0 ]; then
             return 0

--- a/docs/path.md
+++ b/docs/path.md
@@ -1,0 +1,83 @@
+# Brickstrap search path
+The brickstrap search path mechanism provides a way for configuration to be split over re-usable components that may be
+included or excluded based on parameters passed at build time. This document covers:
+ - How brickstrap looks up 'paths' inside a configuration directory hierarchy
+ - What variables influence this behaviour, and what these represent
+ - How this mechanism is used for overriding specific bits and pieces of configuration, depending on parameters at build time.
+ - How a configuration directory hierarchy (a project) may be structured to take full advantage of this.
+ - How you can debug your configuration directory structure to make sure the 'right' configuration is derived from each combination of parameters you wish to support.
+
+## Summary
+The table below summarises how the search path mechanism works and what variables control it:
+
+| Priority  | Variable     | Prefix                 | Disable validation with      |
+|----------:|:-------------|:-----------------------|:-----------------------------|
+| 4         | `BR_VARIANT` | `variant/$BR_VARIANT`  | `BR_IGNORE_INVALID_VARIANT`  |
+| 3         | `BR_BOARD`   | `board/$BR_BOARD`      | `BR_IGNORE_INVALID_BOARD`    |
+| 2         | `BR_ARCH`    | `arch/$BR_ARCH`        | `BR_IGNORE_INVALID_ARCH`     |
+| 1         | `BR_DISTRO`  | `distro/$BR_DISTRO`    | `BR_IGNORE_INVALID_DISTRO`   |
+| 0         | base path    | (none)                 | (not applicable)             |
+
+The various variables may be combined, which yields a combined prefix, starting with the highest priority variable and ending with the lowest one, having a priority of the sum of its parts.
+For example, `BR_DISTRO` may be combined with `BR_ARCH` and `BR_VARIANT` to produce a prefix of `variant/$BR_VARIANT/arch/$BR_ARCH/distro/$BR_DISTRO` with a priority of `(4 + 2 + 1) = 7`.
+All prefixes are interpreted relative to the root of the entire configuration directory hierarchy which is represented by the `BR_PROJECT` variable.
+
+Paths are located on the search path by trying every applicable prefix of higher priority before falling back to a lower priority one, until an applicable path is found.
+As a last resort, the search path mechanism will fall back to `BR_PROJECT`, i.e accept an item relative to the project root itself if it is available.
+
+Search path variables are validated during start up of brickstrap, however by setting the corresponding `BR_IGNORE_INVALID_*` variable validation may be selectively disabled.
+This applies also to `BR_PROJECT`.
+
+The variables may either be set as environment variables prior to invoking brickstrap or passed on the brickstrap commandline using these switches:
+
+|Variable       | Validated switch  | Alternative switch  |
+|:--------------|:------------------|:--------------------|
+| `BR_VARIANT`  | `-v`              | `-V`                |
+| `BR_BOARD`    | `-b`              | `-B`                |
+| `BR_ARCH`     | `-a`              | `-A`                |
+| `BR_DISTRO`   | `-d`              | `-D`                |
+| `BR_PROJECT`  | `-p`              | `-P`                |
+
+The alternative switches are equivalent to setting the corresponding `BR_IGNORE_INVALID_*` variable at the same time, disabling validation of the configurated variable during brickstrap start up.
+
+Functions are provided for user code (such as hooks) to query the search path for a given base path, i.e. to resolve a base path to a single item or a list of applicable candidates.
+See the 'Functions' section for details. User code *should not* attempt to construct paths manually, and configuration *should* be coded to refer to relative paths.
+
+Various debug tools are available which may be used to query a project directory using brickstrap search path mechanism for files and learn which items brickstrap returns for any particular
+combination of variable values.
+
+## Rationale
+Brickstrap uses a concept of 'layering' by which various logically separate directory trees are overlaid on top of each other.
+The purpose of this mechanism is to enable greater reuse of common configuration components or in other words:
+to let you repurpose a project configuration for different environments.
+
+Brickstrap supports four different variables in addition to the project variable `BR_PROJECT` to describe a build environment and derive its complete configuration.
+These four variables are meant solely as descriptive identifiers by which configuration may be partitioned in various sub directories during development and logically 're-assembled' during build.
+*Nota bene*: brickstrap doesn't perform extensive validation of the value for such variables and what validation is performed may be turned off (for development/debug purposes).
+Ultimately, to brickstrap the values of these variables are just arbitrary strings.
+
+ * Variant (`BR_VARIANT`): describes a build variant such as "minimal" or "full"
+ * Board (`BR_BOARD`): describes hardware supported by the project, e.g. "BeagleBone Black" or "my laptop"
+ * Architecture (`BR_ARCH`): describes the system 'architecture' which will be supported by binaries in the built image, e.g. "ARMv7" or "x86_64"
+   Typically this corresponds to the 'architecture' of the Debian repositories used by the build, e.g. "armel" or "amd64".
+ * Distribution  (`BR_DISTRO`): describes the distribution which packages that are downloaded and installed in the image are part of.
+   Typically this corresponds to a code name like "jessie" or "sparkly-unicorn"
+
+Depending on the contents of the project root hierarchy, these variables can be combined to express more complicated scenario's such as:
+"build a minimal image (`minimal`) for Raspberry Pi 2 Model B (`rpi2`) using the Debian Jessie distribution (`jessie`)".
+
+This is an 'opt-in' scheme, configuration directories *may* selectively opt in to specific variables by adopting the necessary directory layout conventions (discussed below) but projects
+are not required to do so. The search path scheme is implemented in such a way that it works also with simple project structures that are entirely unaware of it.
+
+Still it is recommended to adopt the scheme if you wish to support building multiple different versions of an image for the same project. The benefits to you as a maintainer are:
+ * Reduce maintenance workload by sharing common configuration components
+ * Handle hardware, distribution or architecture dependent 'quirks' in your configuration more easily.
+ * Convenience: brickstrap supports setting these variables as part of the brickstrap commandline.
+ * Delegation and partitioning: separate 'concerns' expressed in the configuration are relegated to their own 'parts' of the project hierarchy.
+
+The benefits for end-users of a brickstrap project (configuration) are:
+ * Consistency: brickstrap offers a simple and consistent way to access these features in any project that uses the convention.
+ * Debugging: if something goes wrong, it is easier to pinpoint 'what' part of the configuration is at fault simply by eliminating variables.
+
+
+

--- a/tests/test-paths.sh
+++ b/tests/test-paths.sh
@@ -47,11 +47,11 @@ fi
 
 BR_TEST_CMD="$1" && shift 1 && case "$BR_TEST_CMD" in
     test-env)
-        br_validate_search_path_vars && info "Environment passes validation."
+        brp_validate_search_path_vars && info "Environment passes validation."
     ;;
-    path) br_print_search_paths "$@";;
-    locate) br_print_path "$@";;
-    find) br_print_all_paths "$@";;
-    dir)  br_print_all_dir_listing "$@";;
+    path) brp_print_search_paths "$@";;
+    locate) brp_print_path "$@";;
+    find) brp_print_all_paths "$@";;
+    dir)  brp_print_all_dir_listing "$@";;
     *) fail "Invalid command: '$1'.\nUse: test-env, path, locate, find, dir";;
 esac

--- a/tests/test-paths.sh
+++ b/tests/test-paths.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# This file is part of brickstrap.
+#
+# brickstrap - create a foreign architecture rootfs using kernel namespaces,
+#              multistrap, and qemu usermode emulation and create a disk image
+#              using libguestfs
+#
+# Copyright (C) 2016 Johan Ouwerkerk <jm.ouwerkerk@gmail.com>
+#
+
+#
+# Quick and dirty 'harness' for testing of brickstrap-paths.sh
+# Usage:
+#  1. Prepare a directory tree (test case)
+#  2. Set up BR_PROJECT, BR_VARIANT, BR_BOARD, BR_ARCH, BR_DISTRO to
+#     simulate scenario
+#  3. Optionally, set up BR_IGNORE_INVALID_* variables
+#  4. Call script with a command to test against the test environment.
+#
+
+#
+# Mock logging functions
+#
+
+function fail()
+{
+    echo "FATAL: $1" && exit 1
+}
+
+function info()
+{
+    echo "INFO: $1"
+}
+
+function warn()
+{
+    echo "WARNING: $1"
+}
+
+
+. $(dirname $(readlink -f "$0"))/../brickstrap-paths.sh
+
+if [ $# -eq 0 ]; then
+    fail "Command required!\nUse: test-env, path, locate, find, dir"
+fi
+
+BR_TEST_CMD="$1" && shift 1 && case "$BR_TEST_CMD" in
+    test-env)
+        br_validate_search_path_vars && info "Environment passes validation."
+    ;;
+    path) br_print_search_paths "$@";;
+    locate) br_print_path "$@";;
+    find) br_print_all_paths "$@";;
+    dir)  br_print_all_dir_listing "$@";;
+    *) fail "Invalid command: '$1'.\nUse: test-env, path, locate, find, dir";;
+esac


### PR DESCRIPTION
Add support for a search path mechanism operating on a directory hierarchy.

Variables are introduced to parameterise relative paths based on arch, board, distro and variant values.
(See: br_find_path, br_locate_path, br_locate_directory)

Validation of these variables is added (see: br_validate_search_path_vars).
This validation of such variables may be 'circumvented' by setting a corresponding variable
named BR_IGNORE_INVALID_* (with * being the name of variable to trust blindly).

An override mechanism is introduced based on conceptual layers corresponding to the variables.
(See br_find_path, br_consume_path_list_iterate_directories.)

Additional convenience functions are introduced for producing lists of all paths that match a relative base path.
(See br_list_paths, br_list_directories)

These lists may be iterated over using br_consume_path_list and br_consume_path_list_iterate_directories.
The latter may be used to 'merge' the configuration files in directories.

A few br_print_* functions are added, which could be exposed as debug tools for users of brickstrap (and were used to lightly test the brickstrap-paths.sh code).

N.B.: the code hasn't been extensively tested to see how well it copes with 'special' characters (such as: \, $, @, ', ") in various paths.