### PR TITLE
Extract common code, and cleanup various directory paths.

### DIFF
--- a/brickstrap-argv.sh
+++ b/brickstrap-argv.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+#
+# This file is part of brickstrap.
+#
+# brickstrap - create a foreign architecture rootfs using kernel namespaces,
+#              multistrap, and qemu usermode emulation and create a disk image
+#              using libguestfs
+#
+# Copyright (C) 2016 Johan Ouwerkerk <jm.ouwerkerk@gmail.com>
+#
+
+#
+# Note: this file is not meant to be executed, source it as a library of
+# functions instead. Variables used by the functions (other than stack) are
+# namespaced using the 'BR_' or 'BRP_' prefixes. Function names are namespaced
+# similarly, using the 'br_' and 'brp_' prefixes. See docs/namespacing.md for
+# more information on namespacing in brickstrap.
+#
+
+#
+# Set a single-valued option, if it hasn't been set already.
+# $1: name of the variable to set
+# $2: current value of the same.
+# $3: new value to set
+# $4: failure 'mode' string, values are interpreted as follows:
+#       * Starting with '-' implies a commandline option: failure is
+#         handled using a combination of 'brp_help' and 'exit 1'
+#       * A value of 'error', 'warn', 'info', and 'debug': pass a message
+#         to the correspondig logging function and continue silently.
+#       * A value of 'fail': log a message and terminates the script.
+#       * Any other value implies handling as per default: a message is logged
+#         using 'fail' (and the script is terminated), unless the error can be
+#         recovered from tivrially by ignoring the new value to set. In that
+#         case, a warning message is logged instead and the script continues
+#         silently.
+# $5: short descriptive 'name' for the setting being altered.
+#
+function brp_set_single_value_opt()
+{
+    if [ -z "$3" ]; then
+        case "$4" in
+        -*)
+            brp_help "Empty values are invalid as '$5' setting"
+            exit 1
+        ;;
+        warn|info|error|debug|fail)
+            $4 "Empty values are invalid as '$5' setting"
+        ;;
+        *)  fail "Empty value are invalid as '$5' setting";;
+        esac
+    elif [ -z "$2" ]; then
+        eval "$1=\"$3\""
+    elif [ "$2" = "$3" ]; then
+        case "$4" in
+        -*) warn "Ignoring duplicate value for '$5' setting: $4 '$3'"
+        ;;
+        warn|info|error|debug|fail)
+            $4 "Ignoring duplicate value for '$5' setting: '$3'"
+        ;;
+        *)  warn "Ignoring duplicate value for '$5' setting: '$3'"
+        ;;
+        esac
+    else
+        case "$4" in
+        -*)
+            brp_help "Duplicate value for '$5' setting: $4 '$3'.
+Previous setting: '$2'"
+            exit 1
+        ;;
+        warn|info|error|debug|fail)
+            $4 "Duplicate value for '$5' setting: '$3'.
+Previous setting: '$2'"
+        ;;
+        *)  fail "Duplicate value for '$5' setting: '$3'.
+Previous setting: '$2'";;
+        esac
+    fi
+}
+
+#
+# Append to a multi-valued option (list).
+# $1: name of the variable to append to
+# $2: current value of the same.
+# $3: new value to add
+# $4: failure 'mode' string, values are interpreted as follows:
+#       * Starting with '-' implies a commandline option: failure is
+#         handled using a combination of 'brp_help' and 'exit 1'
+#       * A value of 'error', 'warn', 'info', and 'debug': pass a message
+#         to the correspondig logging function and continue silently.
+#       * A value of 'fail': log a message and terminates the script.
+#       * Any other value implies handling as per default: a message is logged
+#         using 'fail' (and the script is terminated), unless the error can be
+#         recovered from tivrially by ignoring the new value to set. In that
+#         case, a warning message is logged instead and the script continues
+#         silently.
+# $5: short descriptive 'name' for the setting being altered.
+#
+function brp_set_multi_value_opt()
+{
+    if [ -z "$3" ]; then
+        case "$4" in
+        -*)
+            brp_help "Empty values are invalid as '$5' setting"
+            exit 1
+        ;;
+        warn|info|error|debug|fail)
+            $4 "Empty values are invalid as '$5' setting"
+        ;;
+        *)  fail "Empty value are invalid as '$5' setting";;
+        esac
+    elif [ -z "$2" ]; then
+        eval "$1=\"'$3'\""
+    elif echo "$2" | fgrep -q "'$3'"; then
+        case "$4" in
+        -*)
+            warn "Ignoring duplicate value for '$5' setting: $4 '$3'"
+        ;;
+        warn|info|error|debug|fail)
+            $4 "Ignoring duplicate value for '$5' setting: '$3'"
+        ;;
+        *)
+            warn "Ignoring duplicate value for '$5' setting: '$3'"
+        ;;
+        esac
+    else
+        eval "$1=\"$2 '$3'\""
+    fi
+}
+
+#
+# Set up defaults for output destination and image file name.
+# This function is meant to be called when the environment is being set up,
+# after the project config has been sourced, but before brickstrap starts to
+# perform actual work.
+#
+function brp_set_destination_defaults()
+{
+    if [ -z "$BR_DESTDIR" ]; then
+        BR_DESTDIR=$(pwd)
+    fi
+
+    if [ -z "$BR_IMAGE_BASE_NAME" ]; then
+        BR_IMAGE_BASE_NAME="$(basename "$BR_DESTDIR")-$(date +%F)"
+    fi
+}
+
+#
+# Sanity check that image names specified on the commandline do not attempt to
+# escape their directory. (Note: empty image names are valid).
+#
+function brp_validate_image_name()
+{
+    if [ -n "$BR_IMAGE_BASE_NAME" ] &&
+        [ "$(basename "$BR_IMAGE_BASE_NAME")" != "$BR_IMAGE_BASE_NAME" ]; then
+        fail "Invalid image name (not a valid basename): '$BR_IMAGE_BASE_NAME'"
+    fi
+}
+
+#
+# Look up the destination directory to be used for storing brickstrap output.
+#
+function br_dest_dir()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(readlink -f "$BR_DESTDIR")"
+}
+
+#
+# Look up the directory containing the local rootfs directory hierarchy.
+#
+function br_rootfs_dir()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/rootfs"
+}
+
+#
+# Look up the directory for storing disk image files.
+#
+function br_image_dir()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/images"
+}
+
+#
+# Look up the path to the tarball file containing the rootfs.
+#
+function br_tarball_path()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/rootfs.tar"
+}
+
+#
+# Look up the path to a specific disk image, identified by its type extension
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+# $2: the file name extension used to identify the disk image type.
+#
+function br_image_path()
+{
+    [ $# -eq 2 -a -n "$1" -a -n "$2" ] && [ -n "$BR_DESTDIR" ] && \
+        [ -n "$BR_IMAGE_BASE_NAME" ] && \
+        echo -n "$(br_image_dir)/$BR_IMAGE_BASE_NAME-$1.$2";
+}
+
+#
+# Look up the path to a directory inside the rootfs for
+# the private use by brickstrap. This function returns the path on the host
+# filesystem.
+#
+function br_brp_dir()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(br_rootfs_dir)/$(br_chroot_brp_dir)"
+}
+
+#
+# Look up the path to a directory inside the rootfs for
+# the private use by brickstrap. This function returns the path in the chroot
+# filesystem, relative to the root directory (/).
+#
+function br_chroot_brp_dir()
+{
+    echo -n "brickstrap"
+}
+
+#
+# Look up the mount point for the host filesystem inside the chroot (rootfs).
+# This function returns the path in the chroot filesystem, relative to the root
+# directory (/).
+#
+function br_chroot_hostfs_dir()
+{
+    echo -n "$(br_chroot_brp_dir)/host-rootfs"
+}
+
+#
+# Look up the path to the configuration file for use with multistrap
+#
+function br_multistrap_conf()
+{
+    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/multistrap.conf"
+}
+
+#
+# Common, repeated sanity check to make sure the rootfs is available.
+#
+function brp_check_rootfs_dir()
+{
+    if [ ! -d "$(br_rootfs_dir)" ]; then
+        fail "$(br_rootfs_dir) does not exist."
+    fi
+}

--- a/brickstrap.sh
+++ b/brickstrap.sh
@@ -40,35 +40,52 @@ function br_script_path()
     echo -n "$SCRIPT_PATH"
 }
 
+. "$(br_script_path)/brickstrap-argv.sh"
 . "$(br_script_path)/brickstrap-components.sh"
 . "$(br_script_path)/brickstrap-utils.sh"
 
 # Commandline options. This defines the usage page
 BRP_USAGE=$(cat <<'EOF'
-Usage: brickstrap -p <project> [-c <component>] [-d <dir>] <command>
+Usage: brickstrap -p <project> [-c <component>] [-d <dest>] <command>
 
 Options
 -------
 -c <component> Select components from the project directory.
                Multiple components may be selected by specifying multiple '-c'
                options; at least one component must be specified.
--d <dir>       The name of the directory for the rootfs.
-               Note: This is also used for the .tar and .img file names.
+-d <dest>      Destination directory in which brickstrap will store output.
+               This directory will be created if it does not exist.
 -p <project>   Directory which contains the brickstrap configuration (project).
                This option is required and should occur exactly once.
                Values are either a path to the project directory or the name of
                an example project shipped with brickstrap by default.
--Q <qemu>      Optional: override which QEMU binary to use for emulation of
+-I <image>     Optional: name of the disk image file to generate (without type
+               suffix).
+-Q <emulator>  Optional: override which QEMU binary to use for emulation of
                foreign instruction sets.
 
-               The <qemu> value must be either the path to a binary or
+               The <emulator> value must be either the path to a binary or
                the name of a Debian or QEMU architecture or the special string
-               'none'. If <qemu> corresponds to a binary it is used
+               'none'. If <emulator> corresponds to a binary it is used
                unconditionally, without further validation. If <qemu> is an
                architecture which matches the host architecture or 'native'
                then no emulator will be used. Otherwise the system is queried
                for a well known QEMU emulator for the architecture matching the
-               <qemu> value.
+               <emulator> value.
+-x <package>   Blacklist a package (name). The package will not be added to the
+               set of packages to install.
+
+               If the project does not use the PACKAGES variable this setting
+               will have no effect. The blacklist will also not prevent the
+               package from being included as a dependency of the bootstrap or
+               the remaining PACKAGES set.
+-X <filename>  Blacklist a package file from the project. The file will be
+               ignored while determining the set of packages to install.
+
+               If the project does not use the PACKAGES variable this setting
+               will have no effect. The blacklist will also not prevent
+               packages listed in the file from being included as dependencies
+               of the bootstrap or the remaining PACKAGES set.
 -f             Force overwriting existing files/directories.
 -h             Help. (You are looking at it.)
 
@@ -160,53 +177,45 @@ function brp_help() {
 function brp_parse_cli_options()
 {
     while [ $# -gt 0 ] ; do
-        while getopts "fhc:d:p:Q:" BRP_OPT; do
+        while getopts "fhc:d:p:Q:I:x:X:" BRP_OPT; do
             case "$BRP_OPT" in
-            f) FORCE=true;;
+            f)
+                brp_set_single_value_opt BR_FORCE "$BR_FORCE" true \
+                    "-$BRP_OPT" force
+            ;;
             h)
                 brp_help
                 exit 0
             ;;
             p)
-                if [ -z "$OPTARG" ]; then
-                    brp_help 'Empty project names are invalid'
-                    exit 1
-                elif [ -z "$BR_PROJECT" ]; then
-                    BR_PROJECT="$OPTARG"
-                elif [ "$BR_PROJECT" = "$OPTARG" ]; then
-                    warn "Ignoring duplicate project: '$OPTARG'"
-                else
-                    brp_help "Duplicate project: -$BRP_OPT '$OPTARG'.
-Project was: '$BR_PROJECT'"
-                    exit 1
-                fi
+                brp_set_single_value_opt BR_PROJECT "$BR_PROJECT" "$OPTARG" \
+                    "-$BRP_OPT" project
             ;;
             c)
-                if [ -z "$OPTARG" ]; then
-                    brp_help 'Empty component names are invalid'
-                    exit 1
-                elif [ -z "$BR_COMPONENTS" ]; then
-                    BR_COMPONENTS="'$OPTARG'"
-                elif echo "$BR_COMPONENTS" | fgrep -q "'$OPTARG'"; then
-                    warn "Ignoring duplicate component: -$BRP_OPT '$OPTARG'"
-                else
-                    BR_COMPONENTS="$BR_COMPONENTS '$OPTARG'"
-                fi
+                brp_set_multi_value_opt BR_COMPONENTS "$BR_COMPONENTS" \
+                    "$OPTARG" "-$BRP_OPT" component
             ;;
-            d) ROOTDIR="$OPTARG";;
+            d)
+                brp_set_single_value_opt BR_DESTDIR "$BR_DESTDIR" "$OPTARG" \
+                    "-$BRP_OPT" destination
+            ;;
             Q)
-                if [ -z "$OPTARG" ]; then
-                    brp_help 'Empty QEMU architecture names are invalid.'
-                    exit 1
-                elif [ -z "$BR_QEMU" ]; then
-                    BR_QEMU="$OPTARG"
-                elif [ "$BR_QEMU" = "$OPTARG" ]; then
-                    warn "Ignoring duplicate QEMU architecture: '$OPTARG'"
-                else
-                    brp_help "Duplicate QEMU architecture: -$BRP_OPT '$OPTARG'.
-QEMU architecture was: '$BR_QEMU'"
-                    exit 1
-                fi
+                brp_set_single_value_opt BR_QEMU "$BR_QEMU" "$OPTARG" \
+                    "-$BRP_OPT" emulator
+            ;;
+            I)
+                brp_set_single_value_opt BR_IMAGE_BASE_NAME \
+                    "$BR_IMAGE_BASE_NAME" "$OPTARG" "-$BRP_OPT" image
+            ;;
+            x)
+                brp_set_multi_value_opt BR_PACKAGE_BLACKLIST \
+                    "$BR_PACKAGE_BLACKLIST" "$OPTARG" "-$BRP_OPT" \
+                    'package blacklist'
+            ;;
+            X)
+                brp_set_multi_value_opt BR_PACKAGE_FILE_BLACKLIST \
+                    "$BR_PACKAGE_FILE_BLACKLIST" "$OPTARG" "-$BRP_OPT" \
+                    'package file blacklist'
             ;;
             \?) # unknown flag or missing argument
                 brp_help
@@ -245,6 +254,7 @@ function brp_validate_cli_options()
     brp_sanity_check_cli_options "$@"
     brp_validate_project_name
     brp_validate_component_names
+    brp_validate_image_name
     brp_validate_qemu || [ $? -eq 255 ] # no QEMU specified = 255
 }
 
@@ -282,18 +292,15 @@ function brp_init_env()
             'loading'
     fi
 
-    # overwrite target options by commandline options
-    DEFAULT_ROOTDIR=$(readlink -f "$(basename "$BR_PROJECT")-$(date +%F)")
-    ROOTDIR=$(readlink -m ${ROOTDIR:-$DEFAULT_ROOTDIR})
-    MULTISTRAPCONF=$(pwd)/$(basename ${ROOTDIR}).multistrap.conf
-    TARBALL=$(pwd)/$(basename ${ROOTDIR}).tar
-    IMAGE=$(pwd)/$(basename ${ROOTDIR}).img
+    brp_set_destination_defaults
 }
 
 function brp_read_package_file()
 {
     # check that the package file hasn't been blacklisted
-    if echo "$BLACKLIST_PACKAGE_FILES" | fgrep -q "$(basename "$1")"; then
+    if echo "$BLACKLIST_PACKAGE_FILES" | fgrep -q "$(basename "$1")" || \
+        echo "$BR_PACKAGE_FILE_BLACKLIST" | fgrep -q "'$(basename "$1")'"; then
+        info "Skipping blacklisted package file: '$1'"
         return 0
     fi
     while IFS='' read -r BRP_CUR_LINE || [ -n "$BRP_CUR_LINE" ]; do
@@ -304,7 +311,9 @@ function brp_read_package_file()
             # avoid redundant spaces, i.e.  empty lines are ignored.
             # also check that the package line hasn't been blacklisted
             if [ -z "$BRP_CUR_LINE" ] || \
-                echo "$BLACKLIST_PACKAGES" | fgrep -q "$BRP_CUR_LINE"; then
+                echo "$BLACKLIST_PACKAGES" | fgrep -q "$BRP_CUR_LINE" || \
+                echo "$BR_PACKAGE_BLACKLIST" | fgrep -q "'$BRP_CUR_LINE'"; then
+                info "Ignoring blacklisted package: '$BRP_CUR_LINE'"
                 continue
             else
                 PACKAGES="${PACKAGES} $BRP_CUR_LINE"
@@ -317,15 +326,7 @@ function brp_read_package_file()
 function brp_read_multistrap_conf_file()
 {
     while read BRP_CUR_LINE; do
-        eval echo "$BRP_CUR_LINE" >> "$MULTISTRAPCONF"
-        if echo "$BRP_CUR_LINE" | egrep -q "^aptpreferences="
-        then
-                multistrapconf_aptpreferences=true
-        fi
-        if echo "$BRP_CUR_LINE" | egrep -q "^cleanup=true"
-        then
-               multistrapconf_cleanup=true
-        fi
+        eval echo "$BRP_CUR_LINE" >> "$(br_multistrap_conf)"
     done < "$1"
 }
 
@@ -354,11 +355,9 @@ function brp_create_conf() {
             "$(br_list_directories packages)" brp_read_package_file
     fi
 
-    multistrapconf_aptpreferences=false
-    multistrapconf_cleanup=false;
-
-    debug "creating ${MULTISTRAPCONF}"
-    echo -n > "${MULTISTRAPCONF}"
+    debug "creating $(br_multistrap_conf)"
+    mkdir -p "$(dirname "$(br_multistrap_conf)")"
+    echo -n > "$(br_multistrap_conf)"
     br_for_each_path "$(br_list_paths multistrap.conf -f)" \
         brp_read_multistrap_conf_file
 }
@@ -370,30 +369,34 @@ function brp_simulate_multistrap() {
 
 function brp_run_multistrap() {
     info "running multistrap..."
-    [ -z ${FORCE} ] && [ -d "${ROOTDIR}" ] && \
-        fail "${ROOTDIR} already exists. Use -f option to overwrite."
-    debug "MULTISTRAPCONF: ${MULTISTRAPCONF}"
-    debug "ROOTDIR: ${ROOTDIR}"
-    if [ ! -z ${FORCE} ] && [ -d "${ROOTDIR}" ]; then
-        warn "Removing existing rootfs ${ROOTDIR}"
-        brp_unshare -- rm -rf ${ROOTDIR}
+    debug "MULTISTRAPCONF: $(br_multistrap_conf)"
+    debug "ROOTDIR: $(br_rootfs_dir)"
+    if [ -d "$(br_rootfs_dir)" ]; then
+        if [ -n "$BR_FORCE" ]; then
+            warn "Removing existing rootfs $(br_rootfs_dir)"
+            brp_unshare -- rm -rf "$(br_rootfs_dir)"
+        else
+            fail "$(br_rootfs_dir) already exists. Use -f option to overwrite."
+        fi
     fi
-    brp_unshare -- multistrap ${MSTRAP_SIM} --file "${MULTISTRAPCONF}" \
-        --dir ${ROOTDIR} --no-auth
+    mkdir -p "$(br_rootfs_dir)"
+    mkdir -p "$(br_brp_dir)"
+    brp_unshare -- multistrap ${MSTRAP_SIM} --no-auth \
+        --file "$(br_multistrap_conf)" \
+        --dir "$(br_rootfs_dir)"
     brp_setup_qemu_in_rootfs
 }
 
 function brp_copy_to_root_dir() {
-    cp --recursive --dereference "$1/"* "${ROOTDIR}/"
+    cp --recursive --dereference "$1/"* "$(br_rootfs_dir)/"
 }
 
 function brp_copy_root() {
     info "Copying root files from project definition..."
     debug "br_project_dir: $(br_project_dir)"
-    debug "ROOTDIR: ${ROOTDIR}"
-    if [ ! -d "${ROOTDIR}" ]; then
-        fail "${ROOTDIR} does not exist."
-    elif br_list_directories root >/dev/null; then
+    debug "ROOTDIR: $(br_rootfs_dir)"
+    brp_check_rootfs_dir
+    if br_list_directories root >/dev/null; then
         # copy initial directory tree - dereference symlinks
         br_for_each_path "$(br_list_directories root)" brp_copy_to_root_dir
     else
@@ -402,14 +405,14 @@ function brp_copy_root() {
 }
 
 function brp_preseed_debconf() {
-    cp "$1" "${ROOTDIR}/tmp/debconfseed.txt"
+    cp "$1" "$(br_rootfs_dir)/tmp/debconfseed.txt"
     br_chroot debconf-set-selections /tmp/debconfseed.txt
-    rm "${ROOTDIR}/tmp/debconfseed.txt"
+    rm "$(br_rootfs_dir)/tmp/debconfseed.txt"
 }
 
 function brp_configure_packages () {
     info "Configuring packages..."
-    [ ! -d "${ROOTDIR}" ] && fail "${ROOTDIR} does not exist."
+    brp_check_rootfs_dir
 
     # awk needs to be in the path, but Debian symlinks are not
     # configured yet, so make a temporary one in /usr/local/bin.
@@ -426,7 +429,7 @@ function brp_configure_packages () {
 
     # run preinst scripts
     info "running preinst scripts..."
-    BRP_script_dir="${ROOTDIR}/var/lib/dpkg/info"
+    BRP_script_dir="$(br_rootfs_dir)/var/lib/dpkg/info"
     BRP_preinst_blacklist="$(br_cat_files preinst.blacklist)"
     for BRP_script in ${BRP_script_dir}/*.preinst; do
         if echo "$BRP_preinst_blacklist" | \
@@ -436,7 +439,7 @@ function brp_configure_packages () {
             info "running $(basename "$BRP_script")"
                 DPKG_MAINTSCRIPT_NAME=preinst \
                 DPKG_MAINTSCRIPT_PACKAGE="`basename ${BRP_script} .preinst`" \
-                    br_chroot_bind ${BRP_script##$ROOTDIR} install
+                    br_chroot_bind ${BRP_script##$(br_rootfs_dir)} install
         fi
     done
 
@@ -474,12 +477,11 @@ function brp_run_hook_impl()
 }
 
 function brp_run_hook() {
+    brp_check_rootfs_dir
     # completely bogus
     if [ $# -eq 0 -o -z "$1" ]; then
         brp_help "Empty hook names are invalid"
         exit 1
-    elif [ ! -d "${ROOTDIR}" ]; then
-        fail "${ROOTDIR} does not exist."
     # a simple hook name which may or may not map to multiple hooks
     # given the components selection
     elif [ "$(basename "$1")" = "$1" ] || \
@@ -499,9 +501,8 @@ Not part of '$BR_PROJECT' with the given component selection: $BR_COMPONENTS"
 }
 
 function brp_run_hooks() {
-    if [ ! -d "${ROOTDIR}" ]; then
-        fail "${ROOTDIR} does not exist."
-    elif br_list_directories "hooks" >/dev/null; then
+    brp_check_rootfs_dir
+    if br_list_directories "hooks" >/dev/null; then
         info "Running hooks..."
         br_for_each_path_iterate_directories "$(br_list_directories "hooks")" \
             brp_run_hook_impl
@@ -526,20 +527,20 @@ function brp_create_report() {
 }
 
 function brp_copy_to_tar_only() {
-    cp -r "$1/." "${ROOTDIR}/tar-only/"
+    cp -r "$1/." "$(br_brp_dir)/tar-only/"
 }
 
 function brp_create_tar() {
     info "Creating tar of rootfs"
-    debug "ROOTDIR: ${ROOTDIR}"
-    debug "TARBALL: ${TARBALL}"
-    [ ! -d "${ROOTDIR}" ] && fail "${ROOTDIR} does not exist."
-    [ -z ${FORCE} ] && [ -f "${TARBALL}" ] \
-	    && fail "${TARBALL} exists. Use -f option to overwrite."
-    info "creating tarball ${TARBALL}"
+    debug "ROOTDIR: $(br_rootfs_dir)"
+    debug "TARBALL: $(br_tarball_path)"
+    brp_check_rootfs_dir
+    [ -z "$BR_FORCE" ] && [ -f "$(br_tarball_path)" ] \
+	    && fail "$(br_tarball_path) exists. Use -f option to overwrite."
+    info "creating tarball $(br_tarball_path)"
 
     info "Excluding files: "
-    BRP_EXCLUDE_LIST="${ROOTDIR}/tar-exclude"
+    BRP_EXCLUDE_LIST="$(br_brp_dir)/tar-exclude"
     br_cat_files tar-exclude | tee "$BRP_EXCLUDE_LIST" && echo "" # add newline
 
     brp_determine_qemu
@@ -552,15 +553,17 @@ function brp_create_tar() {
     # need to generate tar inside fakechroot
     # so that absolute symlinks are correct
 
-    br_chroot tar cpf /host-rootfs/${TARBALL} --exclude=host-rootfs \
-        --exclude=tar-only --exclude=${BRP_EXCLUDE_LIST##$ROOTDIR/} \
-        --exclude-from=${BRP_EXCLUDE_LIST##$ROOTDIR} .
+    mkdir -p "$(dirname "$(br_tarball_path)")"
+    br_chroot tar cpf "/$(br_chroot_hostfs_dir)/$(br_tarball_path)" \
+        --exclude="$(br_chroot_brp_dir)" \
+        --exclude-from="${BRP_EXCLUDE_LIST##$(br_rootfs_dir)}" .
 
     if br_list_directories tar-only >/dev/null; then
         br_for_each_path "$(br_list_directories tar-only)" brp_copy_to_tar_only
-        if [ -d "${ROOTDIR}/tar-only" ]; then
+        if [ -d "$(br_brp_dir)/tar-only" ]; then
             info "Adding tar-only files:"
-            br_chroot tar rvpf /host-rootfs/${TARBALL} -C /tar-only .
+            br_chroot tar rvpf "/$(br_chroot_hostfs_dir)/$(br_tarball_path)" \
+                -C "/$(br_chroot_brp_dir)/tar-only" .
         fi
     fi
 }
@@ -575,12 +578,12 @@ function brp_create_rootfs () {
 
 function brp_create_image() {
     info "Creating image file..."
-    debug "TARBALL: ${TARBALL}"
-    debug "IMAGE: ${IMAGE}"
+    debug "TARBALL: $(br_tarball_path)"
+    debug "IMAGE: $(br_image_path bootroot img)"
     debug "IMAGE_FILE_SIZE: ${IMAGE_FILE_SIZE}"
-    [ ! -f ${TARBALL} ] && fail "Could not find ${TARBALL}"
-    [ -z ${FORCE} ] && [ -f ${IMAGE} ] && \
-        fail "${IMAGE} already exists. Use -f option to overwrite."
+    [ ! -f "$(br_tarball_path)" ] && fail "Could not find $(br_tarball_path)"
+    [ -z "$BR_FORCE" ] && [ -f "$(br_image_path bootroot img)" ] && \
+        fail "$(br_image_path bootroot img) already exists. Use -f option to overwrite."
 
     # create a disk image with MBR partition table and 2 partitions.
     # ---------------------------------------------
@@ -589,37 +592,38 @@ function brp_create_image() {
     #      1 | boot   | VFAT | 48MB
     #      2 | rootfs | ext4 | ${IMAGE_FILE_SIZE}
     # ---------------------------------------------
-    guestfish -N bootroot:vfat:ext4:${IMAGE_FILE_SIZE}:48M:mbr \
-         part-set-mbr-id /dev/sda 1 0x0b : \
-         set-label /dev/sda2 EV3_FILESYS : \
-         mount /dev/sda2 / : \
-         tar-in ${TARBALL} / : \
-         mkdir-p /media/mmc_p1 : \
-         mount /dev/sda1 /media/mmc_p1 : \
-         glob mv /boot/flash/* /media/mmc_p1/ : \
+    mkdir -p "$(br_image_dir)"
+
+    guestfish -N \
+        "$(br_image_path bootroot img)"=bootroot:vfat:ext4:${IMAGE_FILE_SIZE}:48M:mbr \
+        part-set-mbr-id /dev/sda 1 0x0b : \
+        set-label /dev/sda2 EV3_FILESYS : \
+        mount /dev/sda2 / : \
+        tar-in "$(br_tarball_path)" / : \
+        mkdir-p /media/mmc_p1 : \
+        mount /dev/sda1 /media/mmc_p1 : \
+        glob mv /boot/flash/* /media/mmc_p1/ : \
 
     # Hack to set the volume label on the vfat partition since guestfish does
     # not know how to do that. Must be null padded to exactly 11 bytes.
     echo -e -n "EV3_BOOT\0\0\0" | \
-        dd of=test1.img bs=1 seek=32811 count=11 conv=notrunc >/dev/null 2>&1
-
-    mv test1.img ${IMAGE}
+        dd of="$(br_image_path bootroot img)" \
+            bs=1 seek=32811 count=11 conv=notrunc >/dev/null 2>&1
 }
 
 function brp_delete_all() {
     info "Deleting all files..."
-    brp_unshare -- rm -rf ${ROOTDIR}
-    rm -f ${MULTISTRAPCONF}
-    rm -f ${TARBALL}
-    rm -f ${IMAGE}
+    brp_unshare -- rm -rf "$(br_rootfs_dir)"
+    rm -f "$(br_multistrap_conf)"
+    rm -f "$(br_tarball_path)"
+    rm -rf "$(br_image_dir)"
     info "Done."
 }
 
 function brp_run_shell() {
-    if [ ! -d "${ROOTDIR}" ]; then
-        fail "${ROOTDIR} does not exist."
+    brp_check_rootfs_dir
     # permit the user to select the shell manually
-    elif [ -n "$1" ]; then
+    if [ -n "$1" ]; then
         info "Entering chosen shell: '$1'"
         debian_chroot="brickstrap" PROMPT_COMMAND="" HOME=/root \
             br_chroot_bind "$1"


### PR DESCRIPTION
This change introduces the new brickstrap-argv.sh module.

Changes:

 - Change the -d option to be 'destdir' as opposed to 'rootfs' directory.
   All output of brickstrap should now be generated as files or subdirectorys located within the given 'destdir'.
 - Extract common option parsing code into utility functions
 - Re-organise brickstrap artefacts inside rootfs/chroot.
   Artefacts like tar-only directory or tar-exclude file are now confined to a 'brickstrap' directory hierarchy.
   This way there is a lot less arbitrary poking inside the rootfs going on.
 - Introduce 'images' directory for storing rootfs image files.
   This paves the way for generating multiple images with arbitrary partition layouts.
 - Introduce -I option to specify image base name.
   By default the basename of 'destdir' is used with an appended timestamp.
 - Introduce getter function to lookup various paths, and base paths.
 - Remove numerous globally namespaced variables, notably ROOTDIR.
   (There are 'getter' functions which provide same information more safely now).
 - Introduce -P option for blacklisting individual packages.
   This is a more convenient alternative to BLACKLIST_PACKAGES
 - Introduce -B option for blacklisting entire package files.
   This is a more convenient alternative to BLACKLIST_PACKAGE_FILES
 - Update brickstrap-utils.sh module to take advantage of the changes.
 - Update brickstrap.sh to take advantage the changes.
 - Fix image generation logic to not require a temporary file + mv step, to avoid name clashes.

This change resolves issue #26 (through destdir):
https://github.com/ev3dev/brickstrap/issues/26

See also:
https://github.com/ev3dev/brickstrap/pull/23#discussion_r49371653