### PR TITLE
Allow for custom image partition schemes.

### DIFF
--- a/brickstrap-argv.sh
+++ b/brickstrap-argv.sh
@@ -140,7 +140,7 @@ function brp_set_destination_defaults()
     fi
 
     if [ -z "$BR_IMAGE_BASE_NAME" ]; then
-        BR_IMAGE_BASE_NAME="$(basename "$BR_DESTDIR")-$(date +%F)"
+        BRP_IMAGE_DEFAULT_NAME="$(basename "$BR_DESTDIR")-$(date +%F)"
     fi
 }
 
@@ -189,15 +189,37 @@ function br_tarball_path()
 }
 
 #
-# Look up the path to a specific disk image, identified by its type extension
+# Look up the path to a specific disk image, identified by the name of a
+# partitioning/imaging scheme and its (file) type extension
 # $1: the name of the partitioning/imaging scheme implemented in the disk image
 # $2: the file name extension used to identify the disk image type.
 #
-function br_image_path()
+function brp_image_path()
 {
     [ $# -eq 2 -a -n "$1" -a -n "$2" ] && [ -n "$BR_DESTDIR" ] && \
-        [ -n "$BR_IMAGE_BASE_NAME" ] && \
-        echo -n "$(br_image_dir)/$BR_IMAGE_BASE_NAME-$1.$2";
+        echo -n "$(br_image_dir)/$(brp_image_name "$1" "$2")"
+}
+
+#
+# Look up the (file) name for a specific disk image, identified by the name of
+# a partitioning/imaging scheme and its (file) type extension
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+# $2: the file name extension used to identify the disk image type.
+#
+function brp_image_name()
+{
+    [ $# -eq 2 -a -n "$1" -a -n "$2" ] && if [ -n "$BR_IMAGE_BASE_NAME" ]; then
+        # omit driver name when the image name is configured explicitly (-I)
+        echo -n "$BR_IMAGE_BASE_NAME.$2";
+    elif [ -n "$BRP_IMAGE_DEFAULT_NAME" ]; then
+        # add driver name in the default case, to make workflows involving
+        # multiple create-image commands easier
+        echo -n "$BRP_IMAGE_DEFAULT_NAME-$1.$2";
+    else
+        # something is very wrong, presumably brp_set_destination_defaults has
+        # not been called yet
+        return 1
+    fi
 }
 
 #

--- a/brickstrap-image-drivers.sh
+++ b/brickstrap-image-drivers.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# This file is part of brickstrap.
+#
+# brickstrap - create a foreign architecture rootfs using kernel namespaces,
+#              multistrap, and qemu usermode emulation and create a disk image
+#              using libguestfs
+#
+# Copyright (C) 2016 Johan Ouwerkerk <jm.ouwerkerk@gmail.com>
+#
+
+#
+# Note: this file is not meant to be executed, source it as a library of
+# functions instead. Variables used by the functions (other than stack) are
+# namespaced using the 'BR_' or 'BRP_' prefixes. Function names are namespaced
+# similarly, using the 'br_' and 'brp_' prefixes. See docs/namespacing.md for
+# more information on namespacing in brickstrap.
+#
+
+#
+# This file provides driver functions for default image types supported by
+# brickstrap.
+#
+
+#
+# Implement a boot+root partition scheme.
+# This function creates a 'boot+root' MBR type image (type extension: img).
+# $1: path to the image file to generate.
+#
+function brp_image_drv_bootroot()
+{
+    debug "IMAGE_FILE_SIZE: ${IMAGE_FILE_SIZE}"
+    [ $# -eq 1 -a -n "$1" ] && guestfish -N \
+        "$1"=bootroot:vfat:ext4:${IMAGE_FILE_SIZE}:48M:mbr \
+        part-set-mbr-id /dev/sda 1 0x0b : \
+        set-label /dev/sda2 EV3_FILESYS : \
+        mount /dev/sda2 / : \
+        tar-in "$(br_tarball_path)" / : \
+        mkdir-p /media/mmc_p1 : \
+        mount /dev/sda1 /media/mmc_p1 : \
+        glob mv /boot/flash/* /media/mmc_p1/ : \
+
+    # Hack to set the volume label on the vfat partition since guestfish does
+    # not know how to do that. Must be null padded to exactly 11 bytes.
+    echo -e -n "EV3_BOOT\0\0\0" | \
+        dd of="$1" bs=1 seek=32811 count=11 conv=notrunc >/dev/null 2>&1
+}
+
+#
+# Convert megabytes to sectors. Sectors are assumed to be 512 bytes big.
+# $1 is size in megabytes.
+function brp_to_sector()
+{
+    #echo $(( $1 * 1024 * 1024 / 512 ))
+    echo $(( $1 * 2048 ))
+}
+
+#
+# Create a disk image with MBR partition table and 4 partitions. There are two
+# identical rootfs partitions to allow for failover and live upgrades.
+# ------------------------------------------------------------------------------
+# part | label              | mount point | fs   | size
+# ------------------------------------------------------------------------------
+#    1 | ${BOOT_PART_NAME}  | /boot/flash | VFAT | 48MB
+#    2 | ${ROOT_PART_NAME}1 | /           | ext4 | ${ROOT_PART_SIZE}
+#    3 | ${ROOT_PART_NAME}2 | /mnt/root2  | ext4 | ${ROOT_PART_SIZE}
+#    4 | ${DATA_PART_NAME}  | /var        | ext4 | ${IMAGE_FILE_SIZE} -
+#      |                    |             |      | 2 * ${ROOT_PART_SIZE} - 48MB
+# ------------------------------------------------------------------------------
+#
+# $1: path to the image file to generate.
+#
+function brp_image_drv_redundant_rootfs_w_data()
+{
+    [ $# -eq 1 -a -n "$1" ] && guestfish -N "$1"=disk:${IMAGE_FILE_SIZE} -- \
+        part-init /dev/sda mbr : \
+        part-add /dev/sda primary 0 $(brp_to_sector 48) : \
+        part-add /dev/sda primary $(brp_to_sector 48) $(brp_to_sector ${ROOT_PART_SIZE}) : \
+        part-add /dev/sda primary $(brp_to_sector ${ROOT_PART_SIZE}) $(brp_to_sector $(( 2 * ${ROOT_PART_SIZE} ))) : \
+        part-add /dev/sda primary $(brp_to_sector $(( 2 * ${ROOT_PART_SIZE} ))) -1 : \
+        part-set-mbr-id /dev/sda 1 0x0b : \
+        mkfs fat /dev/sda1 : \
+        set-label /dev/sda1 ${BOOT_PART_NAME} : \
+        mkfs ext4 /dev/sda2 : \
+        set-label /dev/sda2 ${ROOT_PART_NAME}1 : \
+        mkfs ext4 /dev/sda3 : \
+        set-label /dev/sda3 ${ROOT_PART_NAME}2 : \
+        mkfs ext4 /dev/sda4 : \
+        set-label /dev/sda4 ${DATA_PART_NAME} : \
+        mkdir-p /boot/flash : \
+        mount /dev/sda1 /boot/flash : \
+        mount /dev/sda2 / : \
+        mkdir-p /mnt/root2
+        mount /dev/sda3 /var : \
+        mkdir-p /var : \
+        mount /dev/sda4 /var : \
+        tar-in "$(br_tarball_path)" / : \
+        umount /boot/flash : \
+        umount /var : \
+        glob cp-a /* /mnt/root2/ : \
+
+}
+
+#
+# Sanity checks configuration variables for the redundant rootfs + data image
+# type. If variables aren't defined a default is set.
+#
+# Variables:
+# BOOT_PART_NAME: Label of boot partition. Default: BOOT
+# ROOT_PART_NAME: Label of root partition. Default: ROOTFS
+# DATA_PART_NAME: Label of root partition. Default: DATA
+# IMAGE_FILE_SIZE: The size of the entire image file. Default: 3800M
+#
+function brp_image_drv_check_redundant_rootfs_w_data()
+{
+
+    BOOT_PART_NAME=${BOOT_PART_NAME:-BOOT}
+    ROOT_PART_NAME=${ROOT_PART_NAME:-ROOTFS}
+    DATA_PART_NAME=${DATA_PART_NAME:-DATA}
+    IMAGE_FILE_SIZE=${IMAGE_FILE_SIZE:-3800M}
+
+    [ ${#BOOT_PART_NAME} -gt 11 ] && \
+        fail "BOOT_PART_NAME cannot be more than 11 characters."
+
+    # see https://en.wikipedia.org/wiki/Label_%28command%29
+    echo $BOOT_PART_NAME | egrep -q '^[A-Z0-9_-]*$' || \
+        fail "BOOT_PART_NAME contains invalid characters"
+
+    # appending 1/2 to ROOT_PART_NAME, so 16 characters total
+    [ ${#ROOT_PART_NAME} -gt 15 ] && \
+        fail "ROOT_PART_NAME cannot be more than 15 characters."
+    echo $ROOT_PART_NAME | egrep -q '^[a-zA-Z0-9_-]*$' || \
+        fail "ROOT_PART_NAME contains invalid characters"
+
+    [ ${#DATA_PART_NAME} -gt 16 ] && \
+        fail "DATA_PART_NAME cannot be more than 16 characters."
+    echo $DATA_PART_NAME | egrep -q '^[a-zA-Z0-9_-]*$' || \
+        fail "DATA_PART_NAME contains invalid characters"
+}
+
+#
+# Registers the default drivers. To be invoked by brickstrap early before doing
+# any option parsing etc.
+#
+function brp_image_drv_register_defaults()
+{
+    br_register_image_type bootroot brp_image_drv_bootroot \
+        img # no validation required for bootroot, yet
+    br_register_image_type redundant brp_image_drv_redundant_rootfs_w_data \
+        img brp_image_drv_check_redundant_rootfs_w_data
+}
+

--- a/brickstrap-image.sh
+++ b/brickstrap-image.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+#
+# This file is part of brickstrap.
+#
+# brickstrap - create a foreign architecture rootfs using kernel namespaces,
+#              multistrap, and qemu usermode emulation and create a disk image
+#              using libguestfs
+#
+# Copyright (C) 2016 Johan Ouwerkerk <jm.ouwerkerk@gmail.com>
+#
+
+#
+# Note: this file is not meant to be executed, source it as a library of
+# functions instead. Variables used by the functions (other than stack) are
+# namespaced using the 'BR_' or 'BRP_' prefixes. Function names are namespaced
+# similarly, using the 'br_' and 'brp_' prefixes. See docs/namespacing.md for
+# more information on namespacing in brickstrap.
+#
+
+#
+# Default image type 'driver'. This function simply delegates to the current
+# brickstrap default.
+# $1: path to the image file to generate.
+#
+function brp_image_default_driver()
+{
+    brp_image_drv_bootroot "$1"
+}
+
+#
+# Default image type configuration validator. This function simply delegates to
+# the current brickstrap default.
+#
+function brp_validate_default_image_config()
+{
+    true # there is no validation required for the simple bootroot driver, yet
+}
+
+#
+# Displays an error message if a image type driver failed to create an image
+# file successfully. Returns the given status code.
+# $1: the status code returned by the driver function
+# $2: the name of the partitioning/imaging scheme implemented in the disk image
+# $3: the file path of the disk image
+#
+function brp_image_err_msg()
+{
+    error "Unable to create image: '$3'.
+Driver '$2' ($(brp_get_image_type_driver "$2")) returned status code: $1"
+    return $1
+}
+
+#
+# Create a disk image file (type). This function looks up the
+# relevant driver and invokes it with the given path. Before creating the image
+# this function checks it does not already exist or, if it does, that it may be
+# overwritten.
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+#
+function brp_create_image_type()
+{
+    if [ $# -eq 0 -o -z "$1" ]; then
+        error "Image type required!"
+        return 1
+    elif [ -z "$(brp_get_image_type_driver "$1")" ]; then
+        error "Unable to create image: '$2'.
+No driver for image type: '$1'"
+        return 1
+    fi
+    BRP_CUR_IMG="$(brp_image_path "$1" "$(brp_get_image_type_extension $1)")"
+    debug "IMAGE: $BRP_CUR_IMG"
+    if [ -z "$BR_FORCE" -a -f "$BRP_CUR_IMG" ]; then
+        error "$BRP_CUR_IMG already exists. Use -f option to overwrite."
+        return 1
+    else
+        eval "$(brp_get_image_type_driver "$1")" "$BRP_CUR_IMG" || \
+            brp_image_err_msg "$?" "$1" "$BRP_CUR_IMG"
+    fi
+}
+
+#
+# Look up the driver function for a given image type name.
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+#
+function brp_get_image_type_driver()
+{
+    [ $# -eq 1 -a -n "$1" ] && case "$1" in
+        default)
+            echo -n brp_image_default_driver
+        ;;
+        *)
+            eval echo -n "\$BRP_IMG_DRV_REGISTRY_$1"
+        ;;
+    esac
+}
+
+#
+# Look up the file type extension for a given image type name.
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+#
+function brp_get_image_type_extension()
+{
+    [ $# -eq 1 -a -n "$1" ] && case "$1" in
+        default)
+            echo -n img
+        ;;
+        *)
+            eval echo -n "\$BRP_IMG_EXT_REGISTRY_$1"
+        ;;
+    esac
+}
+
+#
+# Look up the validator function to check image configuration parameters.
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+#
+function brp_get_image_cfg_validator()
+{
+    [ $# -eq 1 -a -n "$1" ] && case "$1" in
+        default)
+            echo -n brp_validate_default_image_config
+        ;;
+        *)
+            eval echo -n "\$BRP_IMG_CFG_VALIDATOR_$1"
+        ;;
+    esac
+}
+
+#
+# Register a custom driver with brickstrap for a custom image type.
+# $1: the name of the partitioning/imaging scheme implemented in the disk image
+# $2: name of the function which will create the image (type), taking the image
+#     file path as argument.
+# $3: the image file type extension, without leading dot.
+# $4: optional: a validator function to check parameters intended for the image
+#     driver function in the project configuration.
+#
+function br_register_image_type()
+{
+    if [ $# -lt 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+        fail "Bad call to br_register_image_type:
+Usage: br_register_image_type <name> <driver_func> <ext> [cfg_validator_func]"
+    elif [ -z "$(brp_get_image_type_driver "$1")" ]; then
+        eval "BRP_IMG_DRV_REGISTRY_$1=$2"
+        eval "BRP_IMG_EXT_REGISTRY_$1=$3"
+        if [ -n "$4" ]; then
+            eval "BRP_IMG_CFG_VALIDATOR_$1=$4"
+        fi
+    else
+        fail "Rejected duplicate driver '$2' for image type: '$1'
+Previous setting was: $(brp_get_image_type_driver "$1")"
+    fi
+}
+
+#
+# Validates image driver specific settings in the project configuration.
+#
+function brp_validate_image_configuration()
+{
+    if [ -n "$(brp_get_image_cfg_validator "$(br_image_type)")" ]; then
+        eval "$(brp_get_image_cfg_validator "$(br_image_type)")"
+    fi
+}
+
+#
+# Creates a disk image for the configured image type.
+#
+function brp_create_image()
+{
+    info "Creating image files..."
+    debug "TARBALL: $(br_tarball_path)"
+    [ ! -f "$(br_tarball_path)" ] && fail "Could not find $(br_tarball_path)"
+
+    mkdir -p "$(br_image_dir)"
+    brp_create_image_type "$(br_image_type)"
+}
+
+#
+# Look up which driver type to use for creating an image.
+#
+function br_image_type()
+{
+    if [ -n "$BR_IMAGE_TYPE" ]; then
+        echo -n "$BR_IMAGE_TYPE"
+    elif [ -n "$DEFAULT_IMAGE_TYPE" ]; then
+        echo -n "$DEFAULT_IMAGE_TYPE"
+    else
+        echo -n default
+    fi
+}
+
+#
+# Convenience version of brp_image_path() so hooks and reporting scripts
+# do not need to know how to call it.
+#
+function br_image_path()
+{
+    brp_image_path "$(br_image_type)" \
+        "$(brp_get_image_type_extension "$(br_image_type)")"
+}
+
+#
+# Convenience version of brp_image_name() so hooks and reporting scripts
+# do not need to know how to call it.
+#
+function br_image_name()
+{
+    brp_image_name "$(br_image_type)" \
+        "$(brp_get_image_type_extension "$(br_image_type)")"
+}


### PR DESCRIPTION
This commit provides preliminary support for custom partitioning schemes/image file types.
For discussion refer to: issue #10:
https://github.com/ev3dev/brickstrap/issues/10

This change assumes some artefacts provided by PR #28 are available:
https://github.com/ev3dev/brickstrap/pull/28
Specifically: br_image_dir() and br_image_path() functions.

This change does **not** address integration within brickstrap.sh itself (should be trivial, though).