### PR TITLE
Minor enhancements/fixes.

### DIFF
--- a/brickstrap-argv.sh
+++ b/brickstrap-argv.sh
@@ -136,11 +136,11 @@ function brp_set_multi_value_opt()
 function brp_set_destination_defaults()
 {
     if [ -z "$BR_DESTDIR" ]; then
-        BR_DESTDIR=$(pwd)
+        BRP_DEFAULT_DESTDIR=$(pwd)
     fi
 
     if [ -z "$BR_IMAGE_BASE_NAME" ]; then
-        BRP_IMAGE_DEFAULT_NAME="$(basename "$BR_DESTDIR")-$(date +%F)"
+        BRP_IMAGE_DEFAULT_NAME="$(basename "$(br_dest_dir)")-$(date +%F)"
     fi
 }
 
@@ -161,7 +161,11 @@ function brp_validate_image_name()
 #
 function br_dest_dir()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(readlink -f "$BR_DESTDIR")"
+    if [ -n "$BR_DESTDIR" ]; then
+        echo -n "$(readlink -f "$BR_DESTDIR")"
+    else
+        echo -n "$(readlink -f "$BRP_DEFAULT_DESTDIR")"
+    fi
 }
 
 #
@@ -169,7 +173,7 @@ function br_dest_dir()
 #
 function br_rootfs_dir()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/rootfs"
+    echo -n "$(br_dest_dir)/rootfs"
 }
 
 #
@@ -177,7 +181,7 @@ function br_rootfs_dir()
 #
 function br_image_dir()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/images"
+    echo -n "$(br_dest_dir)/images"
 }
 
 #
@@ -185,7 +189,7 @@ function br_image_dir()
 #
 function br_tarball_path()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/rootfs.tar"
+    echo -n "$(br_dest_dir)/rootfs.tar"
 }
 
 #
@@ -196,7 +200,7 @@ function br_tarball_path()
 #
 function brp_image_path()
 {
-    [ $# -eq 2 -a -n "$1" -a -n "$2" ] && [ -n "$BR_DESTDIR" ] && \
+    [ $# -eq 2 -a -n "$1" -a -n "$2" ] && \
         echo -n "$(br_image_dir)/$(brp_image_name "$1" "$2")"
 }
 
@@ -229,7 +233,7 @@ function brp_image_name()
 #
 function br_brp_dir()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(br_rootfs_dir)/$(br_chroot_brp_dir)"
+    echo -n "$(br_rootfs_dir)/$(br_chroot_brp_dir)"
 }
 
 #
@@ -257,7 +261,7 @@ function br_chroot_hostfs_dir()
 #
 function br_multistrap_conf()
 {
-    [ -n "$BR_DESTDIR" ] && echo -n "$(br_dest_dir)/multistrap.conf"
+    echo -n "$(br_dest_dir)/multistrap.conf"
 }
 
 #

--- a/brickstrap-components.sh
+++ b/brickstrap-components.sh
@@ -18,6 +18,126 @@
 #
 
 #
+# Extract the component from a file inside a project structure.
+# This works only for files inside the component directory itself.
+# $1: path to translate back to its component name
+#
+function brp_path_to_component()
+{
+    [ $# -eq 1 -a -n "$1" ] && dirname "${1##$(br_project_dir)/}"
+}
+
+#
+# Read an include file which lists components to add, one per line.
+# $1: the file to read.
+#
+function brp_read_include_file()
+{
+    # Add component name to list of extra components.
+    # Avoid duplicate component names being added to BRP_EXTRA_COMPONENTS
+    # This could otherwise happen if components from BR_COMPONENTS are also
+    # listed in parsed include files.
+    #
+    BRP_IMPORTED_COMPONENT="$(brp_path_to_component "$1")"
+    brp_is_component_included "$BRP_IMPORTED_COMPONENT" || \
+    if [ -z "$BRP_EXTRA_COMPONENTS" ]; then
+        BRP_EXTRA_COMPONENTS="'$BRP_IMPORTED_COMPONENT'"
+    else
+        BRP_EXTRA_COMPONENTS="$BRP_EXTRA_COMPONENTS '$BRP_IMPORTED_COMPONENT'"
+    fi
+
+    # Read include file
+    while IFS='' read -r BRP_CUR_LINE || [ -n "$BRP_CUR_LINE" ]; do
+        case "$BRP_CUR_LINE" in
+        \#*|\;*) # permit comments: lines starting with # or ; are ignored.
+        ;;
+        *)
+            # avoid redundant spaces, i.e.  empty lines are ignored.
+            # avoid adding duplicate component names
+            if [ -z "${BRP_CUR_LINE##/}" ] || \
+                brp_is_component_included "$BRP_CUR_LINE" || \
+                br_is_component_inherited "$BRP_CUR_LINE"; then
+                continue
+            else
+                brp_validate_component_name "$BRP_CUR_LINE"
+                if [ -z "$BRP_INCLUDES" ]; then
+                    BRP_INCLUDES="'${BRP_CUR_LINE##/}'"
+                else
+                    BRP_INCLUDES="$BRP_INCLUDES '${BRP_CUR_LINE##/}'"
+                fi
+            fi
+        ;;
+        esac
+    done < "$1"
+}
+
+function br_is_component_selected()
+{
+    [ $# -eq 1 -a -n "${1##/}" ] && \
+        echo -n "$BR_COMPONENTS" | fgrep -q "'${1##/}'"
+}
+
+function br_is_component_inherited()
+{
+    [ $# -eq 1 -a -n "${1##/}" ] && \
+        echo -n "$BRP_INCLUDES" | fgrep -q "'${1##/}'"
+}
+
+function brp_is_component_imported()
+{
+    [ $# -eq 1 -a -n "${1##/}" ] && \
+        echo -n "$BRP_EXTRA_COMPONENTS" | fgrep -q "'${1##/}'"
+}
+
+function brp_is_component_included()
+{
+    br_is_component_imported "$1" || brp_is_component_selected "$1"
+}
+
+function brp_is_new_include_file()
+{
+    if brp_is_component_included "$(brp_path_to_component "$1")"; then
+        return 1
+    elif br_is_component_inherited "$(brp_path_to_component "$1")" && \
+        [ -r "$1" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#
+# Import extra components by reading include file. This function will
+# iteratively import include files (resolving recursive include structures).
+# Importing terminates once there are no 'new' readable include files left to
+# process.
+#
+function brp_import_extra_components()
+{
+    # for the first round of imports all files are 'new' by definition.
+    BRP_IMPORT_CHECK=-r
+    BRP_INCLUDES=""
+    while br_list_paths include $BRP_IMPORT_CHECK >/dev/null; do
+        br_for_each_path "$(br_list_paths include $BRP_IMPORT_CHECK)" \
+            brp_read_include_file || fail "Failed to process 'include' files"
+        BRP_IMPORT_CHECK=brp_is_new_include_file
+    done
+    BRP_EXTRA_COMPONENTS="$BRP_INCLUDES"
+    debug "Selected components: $BR_COMPONENTS"
+    debug "Inherited components: $BRP_INCLUDES"
+}
+
+
+#
+# Look up path to the root directory of example/default projects shipped with
+# brickstrap.
+#
+function brp_default_projects_tree()
+{
+    echo -n "$(br_script_path)/projects"
+}
+
+#
 # Checks that a project path doesn't map to a 'reserved' brickstrap directory.
 # Reserved brickstrap directories are directories underneath $(br_script_path)
 # which are part of brickstrap source, tests or documentation as opposed to the
@@ -33,15 +153,17 @@ function brp_validate_project_path()
     # Start with simple check allow $1 if it doesn't start with br_script_path
     [ $# -eq 1 -a -n "$1" ] && if [ "${1##$(br_script_path)}" = "$1" ]; then
         BR_PROJECT_DIR="$1"
-    # Allow $1 if it isn't blacklisted.
-    elif [ "$(br_script_path)" != "$1" ] && \
-        [ "${1##$(br_script_path)/tests}" = "$1" ] && \
-        [ "${1##$(br_script_path)/docs}" = "$1" ]; then
-        BR_PROJECT_DIR="$1"
-    else
+    # Test if $1 maps to a blacklisted directory.
+    # If control flow gets to the 'elif', it means $1 must reside somewhere
+    # in the $(br_script_path) hierarchy. If the string comparison succeeds,
+    # it means the project path also lives outside the
+    # $(brp_default_projects_tree) hierarchy which means it is invalid.
+    elif [ "${1##$(brp_default_projects_tree)}" = "$1" ]; then
         fail "Invalid project name: '$BR_PROJECT'.
 Directory does not exist: '$BR_PROJECT'
 Directory is reserved/disallowed: '$1'"
+    else
+        BR_PROJECT_DIR="$1"
     fi
 }
 
@@ -56,9 +178,8 @@ Directory is reserved/disallowed: '$1'"
 #
 function brp_validate_component_path()
 {
-    # Use a similar trick to brp_validate_project_path, but opposite:
     # If the string comparison succeeds, it means the component path lives
-    # outside the project directory, which is invalid.
+    # outside the project directory which is invalid.
     [ $# -eq 2 ] && if [ "${1##$(br_project_dir)}" = "$1" ]; then
         fail "Invalid component name: '$2'
 Directory outside the project: '$1'
@@ -78,14 +199,14 @@ function brp_validate_project_name()
         fail "No project specified (project name must not be empty)"
     elif [ -r "$BR_PROJECT" -a -d "$BR_PROJECT" ]; then
         brp_validate_project_path "$(readlink -f "$BR_PROJECT")"
-    elif [ -r "$(br_script_path)/projects/$BR_PROJECT" ] && \
-        [ -d "$(br_script_path)/projects/$BR_PROJECT" ]; then
+    elif [ -r "$(brp_default_projects_tree)/$BR_PROJECT" ] && \
+        [ -d "$(brp_default_projects_tree)/$BR_PROJECT" ]; then
         brp_validate_project_path \
-            "$(readlink -f "$(br_script_path)/projects/$BR_PROJECT")"
+            "$(readlink -f "$(brp_default_projects_tree)/$BR_PROJECT")"
     else
         fail "Invalid project name (no such directory): '$BR_PROJECT'.
 Directory does not exist: '$BR_PROJECT'
-Directory does not exist: '$(br_script_path)/projects/$BR_PROJECT'"
+Directory does not exist: '$(brp_default_projects_tree)/$BR_PROJECT'"
     fi
 }
 
@@ -134,7 +255,34 @@ function brp_validate_component_names()
 # Iterate over the configured component names (commandline arguments), invoking
 # callback for each component name. The calling convention is such that the
 # component name is passed as first argument to the callback, and any extra
-# arguments passed to this function are passed along to the callback aftet the
+# arguments passed to this function are passed along to the callback after the
+# component name.
+#
+# $1: the list of components to iterate over.
+# $2: the callback to invoke.
+# $3...: optional: additional arguments passed to the callback following the
+#                  component name.
+#
+function brp_iterate_components_impl()
+{
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        return 1
+    else
+        BRP_COMP_CB_RETURNCODE=0
+        for BRP_PATHS_CUR_COMP in $1; do
+            eval "BRP_PATHS_CUR_COMP=$BRP_PATHS_CUR_COMP" # unwraps quotes
+            "$2" "${BRP_PATHS_CUR_COMP##/}" "${@:3:$#}" || \
+                BRP_COMP_CB_RETURNCODE=$?
+        done && return $BRP_COMP_CB_RETURNCODE
+    fi
+}
+
+
+#
+# Iterate over the configured component names (commandline arguments), invoking
+# callback for each component name. The calling convention is such that the
+# component name is passed as first argument to the callback, and any extra
+# arguments passed to this function are passed along to the callback after the
 # component name.
 #
 # $1: the callback to invoke.
@@ -143,15 +291,12 @@ function brp_validate_component_names()
 #
 function brp_iterate_components()
 {
-    if [ -z "$BR_COMPONENTS" -o $# -eq 0 -o -z "$1" ]; then
+    if [ -z "$BR_COMPONENTS" ]; then
         return 1
+    elif [ -n "$BRP_EXTRA_COMPONENTS" ]; then
+        brp_iterate_components_impl "$BR_COMPONENTS $BRP_EXTRA_COMPONENTS" "$@"
     else
-        BR_PATHS_CB_RETURNCODE=0
-        for BRP_PATHS_CUR_FILE in $BR_COMPONENTS; do
-            eval "BRP_PATHS_CUR_FILE=$BRP_PATHS_CUR_FILE" # unwraps quotes
-            "$1" "${BRP_PATHS_CUR_FILE##/}" "${@:2:$#}" || \
-                BR_PATHS_CB_RETURNCODE=$?
-        done && return "$BR_PATHS_CB_RETURNCODE"
+        brp_iterate_components_impl "$BR_COMPONENTS" "$@"
     fi
 }
 

--- a/brickstrap.sh
+++ b/brickstrap.sh
@@ -270,7 +270,6 @@ function brp_validate_cli_options()
     brp_validate_qemu || [ $? -eq 255 ] # no QEMU specified = 255
 }
 
-
 #####################################################################
 ### Set up the variables for the commands
 
@@ -283,9 +282,6 @@ function brp_init_env()
     export LC_ALL=C LANGUAGE=C LANG=C
     export PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
 
-    br_list_paths "multistrap.conf" -r >/dev/null || \
-        fail "Unable to locate a readable 'multistrap.conf'"
-
     for SYSTEM_KERNEL_IMAGE in /boot/vmlinuz-*; do
         [ -r "${SYSTEM_KERNEL_IMAGE}" ] \
             || fail "Cannot read ${SYSTEM_KERNEL_IMAGE} needed by guestfish." \
@@ -296,6 +292,8 @@ function brp_init_env()
         fail "Unprivileged user namespace clone is disabled. Enable it by running" \
             "'sudo sysctl -w kernel.unprivileged_userns_clone=1'."
     fi
+
+    brp_import_extra_components
 
     # source project config file
     if br_list_paths config -r >/dev/null; then
@@ -308,6 +306,13 @@ function brp_init_env()
         br_for_each_path "$(br_list_paths custom-image.sh -r)" \
             brp_run_hook_impl 'loading'
     fi
+
+    # revalidate component names.
+    # just in case someone redefines EXTRA_COMPONENTS in custom-image.sh
+    brp_validate_component_names
+
+    br_list_paths "multistrap.conf" -r >/dev/null || \
+        fail "Unable to locate a readable 'multistrap.conf'"
 
     brp_set_destination_defaults
     brp_validate_image_configuration
@@ -328,9 +333,11 @@ function brp_read_package_file()
         *)
             # avoid redundant spaces, i.e.  empty lines are ignored.
             # also check that the package line hasn't been blacklisted
-            if [ -z "$BRP_CUR_LINE" ] || \
-                echo "$BLACKLIST_PACKAGES" | fgrep -q "$BRP_CUR_LINE" || \
-                echo "$BR_PACKAGE_BLACKLIST" | fgrep -q "'$BRP_CUR_LINE'"; then
+            if [ -z "$BRP_CUR_LINE" ]; then
+                continue
+            elif echo "$BLACKLIST_PACKAGES" | fgrep -q "$BRP_CUR_LINE" || \
+                    echo "$BR_PACKAGE_BLACKLIST" | fgrep -q "'$BRP_CUR_LINE'"
+            then
                 info "Ignoring blacklisted package: '$BRP_CUR_LINE'"
                 continue
             else
@@ -428,15 +435,71 @@ function brp_preseed_debconf() {
     rm "$(br_rootfs_dir)/tmp/debconfseed.txt"
 }
 
+#
+# Ensure that a 'usable' /etc/shells file exists for the add-shell utility.
+# This ensures that configuration of shell packages (dash in particular) do
+# not fail with spurious error messages from misbehaving add-shell.
+# The add-shell utility of debianutils (at least version 4.6) may fail on
+# empty/missing /etc/shells file with a bogus error message.
+#
+function brp_fixup_etc_shells()
+{
+    info "Checking /etc/shells"
+    if [ ! -f "$(br_rootfs_dir)/etc/shells" ] ||
+        [ ! -s "$(br_rootfs_dir)/etc/shells" ]; then
+        if [ -f "$(br_rootfs_dir)/usr/share/debianutils/shells" ] &&
+            [ -s "$(br_rootfs_dir)/usr/share/debianutils/shells" ]; then
+            info "Populating default /etc/shells from template"
+            cp "$(br_rootfs_dir)/usr/share/debianutils/shells" \
+                "$(br_rootfs_dir)/etc/shells"
+        else
+            info "Generating dummy contents for: /etc/shells"
+            echo "# Dummy comment to work around add-shell bug" >\
+                "$(br_rootfs_dir)/etc/shells"
+        fi
+    else
+        info "Default /etc/shells appears to be sane... skipping"
+    fi
+}
+
 function brp_configure_packages () {
     info "Configuring packages..."
     brp_check_rootfs_dir
+    BRP_OLD_PATH="$PATH"
+    BRP_W_AWK_PATH="$PATH"
 
     # awk needs to be in the path, but Debian symlinks are not
-    # configured yet, so make a temporary one in /usr/local/bin.
-    info "Creating awk temporary symlink"
-    br_chroot mkdir -p /usr/local/bin
-    br_chroot ln -sf /usr/bin/gawk /usr/local/bin/awk
+    # configured yet, so make a temporary one in /$(br_chroot_brp_dir)/bin
+    # then export the dir on the PATH.
+    #
+    if br_chroot which awk >/dev/null; then
+        info "Using existing 'awk': $(br_chroot which awk)"
+    elif [ -x "/$(br_chroot_brp_dir)/bin/awk" ]; then
+        info "Reusing old temporary symlink: /$(br_chroot_brp_dir)/bin/awk"
+        BRP_W_AWK_PATH="$BRP_W_AWK_PATH:/$(br_chroot_brp_dir)/bin"
+    else
+        info "Creating awk temporary symlink: /$(br_chroot_brp_dir)/bin/awk"
+        br_chroot mkdir -p "/$(br_chroot_brp_dir)/bin"
+        BRP_W_AWK_PATH="$BRP_W_AWK_PATH:/$(br_chroot_brp_dir)/bin"
+        #
+        # Do not hard-depend on gawk, because it is an optional package.
+        # Someone might try to bootstrap Debian without it.
+        # (By contrast: mawk has priority 'required').
+        #
+        if [ -e "$(br_rootfs_dir)/usr/bin/gawk" ]; then
+            info "Using 'gawk' to provide /$(br_chroot_brp_dir)/bin/awk"
+            br_chroot ln -sf /usr/bin/gawk "/$(br_chroot_brp_dir)/bin/awk"
+        elif [ -e "$(br_rootfs_dir)/usr/bin/mawk" ]; then
+            info "Using 'mawk' to provide /$(br_chroot_brp_dir)/bin/awk"
+            br_chroot ln -sf /usr/bin/mawk "/$(br_chroot_brp_dir)/bin/awk"
+        else
+            fail "No 'awk' available in: $(br_rootfs_dir)
+Tried: /usr/bin/gawk
+Tried: /usr/bin/mawk"
+        fi
+    fi
+
+    export PATH="$BRP_W_AWK_PATH"
 
     # preseed debconf
     if br_list_paths debconfseed.txt -r >/dev/null; then
@@ -461,14 +524,18 @@ function brp_configure_packages () {
         fi
     done
 
-    # run dpkg `--configure -a` twice because of errors during the first run
+    brp_fixup_etc_shells
+
     info "configuring packages..."
-    br_chroot_bind /usr/bin/dpkg --configure -a || \
-    br_chroot_bind /usr/bin/dpkg --configure -a || true
+    br_chroot_bind /usr/bin/dpkg --configure -a
+
+    export PATH="$BRP_OLD_PATH"
 
     # remove our temporary awk symlink as it is no longer required.
-    info "Removing awk temporary symlink"
-    br_chroot rm -f /usr/local/bin/awk
+    if [ -x "/$(br_chroot_brp_dir)/bin/awk" ]; then
+        info "Removing awk temporary symlink"
+        br_chroot rm -f "/$(br_chroot_brp_dir)/bin/awk"
+    fi
 }
 
 function brp_report_hooks_exit_code()
@@ -600,6 +667,16 @@ function brp_delete_all() {
     rm -f "$(br_multistrap_conf)"
     rm -f "$(br_tarball_path)"
     rm -rf "$(br_image_dir)"
+    BRP_PWD=$(pwd)
+
+    # if the current working directory is at or underneath the destination
+    # directory, do the safe thing: don't rm -rf, warn about it instead.
+    if [ "${BRP_PWD##$(br_dest_dir)}" != "$BRP_PWD" ]; then
+        warn "Not removing output destination directory: '$(br_dest_dir)'
+To fix this manually, try: rm -rf '$(br_dest_dir)'"
+    else
+        rm -rf "$(br_dest_dir)"
+    fi
     info "Done."
 }
 


### PR DESCRIPTION
 - Fix: delete destination directory if possible & sensible. See issue #34
   https://github.com/ev3dev/brickstrap/issues/34
 - Make it easier to detect in brickstrap code if '-d' option was specified by moving the default destination directory value to its own variable.
 - Enhancement: permit component inheritance through specifying EXTRA_COMPONENTS in config. See issue #32
   https://github.com/ev3dev/brickstrap/issues/32
 - Tighten validation of project directories.
   With the move to a unified projects/ hierarchy for default/example projects shipped with the brickstrap code, the validation logic for the -p switch needs a corresponding update to reflect this.