### PR TITLE
Check if /brickstrap/_tar-exclude exists in docker

### DIFF
--- a/brickstrap.sh
+++ b/brickstrap.sh
@@ -63,9 +63,10 @@ function brickstrap_create_tar()
     if dpkg --compare-versions $BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION ge 1.28; then
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-ignore .brickstrap-tar-exclude"
     else
-        BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-from /brickstrap/_tar-exclude"
+        if docker run --rm $BRICKSTRAP_DOCKER_IMAGE_NAME test -f /brickstrap/_tar-exclude; then
+            BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-from /brickstrap/_tar-exclude"
+        fi
     fi
-
 
     # Then create the actual image
 


### PR DESCRIPTION
Brickstrap fails if we don't check that `/brickstrap/_tar-exclude` exists.

```
➜ viki:git$ ./brickstrap/brickstrap.sh create-tar b01ab378b678 OUTPUT.tar
Checking docker image tar version...
tar 1.27.1-2+b1
Creating OUTPUT.tar from b01ab378b678...
/bin/tar: /brickstrap/_tar-exclude: No such file or directory
/bin/tar: Error is not recoverable: exiting now
```

See #60.