### PR TITLE
Use built-in tar version command instead of dpkg

### DIFF
--- a/src/brickstrap.sh
+++ b/src/brickstrap.sh
@@ -51,17 +51,17 @@ function brickstrap_create_tar()
         exit 1
     fi
 
-    # --exclude-ignore requires tar >= 1.28, so first we check the tar version in
+    # --exclude-ignore requires tar > 1.27, so first we check the tar version in
     # the docker image.
 
     echo "Checking docker image tar version..."
 
-    BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION=$(docker run --rm --user root $BRICKSTRAP_DOCKER_IMAGE_NAME \
-        dpkg-query --show --showformat '${Version}' tar)
-
+    BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION="$(docker run --rm --user root $BRICKSTRAP_DOCKER_IMAGE_NAME \
+        tar --version | head -1 | cut -d\  -f 4)"
     echo "tar $BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION"
 
-    if dpkg --compare-versions $BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION ge 1.28; then
+    SORTED_VERSION="$(echo "${BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION}"$'\n'"1.27" | sort -Vr | head -1)"
+    if [ "${SORTED_VERSION}" != "1.27" ]; then # BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION > 1.27
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-ignore .brickstrap-tar-exclude"
     elif docker run --rm --user root $BRICKSTRAP_DOCKER_IMAGE_NAME test -f /brickstrap/_tar-exclude; then
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-from /brickstrap/_tar-exclude"

--- a/src/brickstrap.sh
+++ b/src/brickstrap.sh
@@ -51,7 +51,7 @@ function brickstrap_create_tar()
         exit 1
     fi
 
-    # --exclude-ignore requires tar > 1.27, so first we check the tar version in
+    # --exclude-ignore requires tar > 1.27.1, so first we check the tar version in
     # the docker image.
 
     echo "Checking docker image tar version..."
@@ -60,8 +60,8 @@ function brickstrap_create_tar()
         tar --version | head -1 | cut -d\  -f 4)"
     echo "tar $BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION"
 
-    SORTED_VERSION="$(echo "${BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION}"$'\n'"1.27" | sort -Vr | head -1)"
-    if [ "${SORTED_VERSION}" != "1.27" ]; then # BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION > 1.27
+    SORTED_VERSION="$(echo "${BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION}"$'\n'"1.27.1" | sort -Vr | head -1)"
+    if [ "${SORTED_VERSION}" != "1.27.1" ]; then # BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION > 1.27.1
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-ignore .brickstrap-tar-exclude"
     elif docker run --rm --user root $BRICKSTRAP_DOCKER_IMAGE_NAME test -f /brickstrap/_tar-exclude; then
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-from /brickstrap/_tar-exclude"

--- a/src/brickstrap.sh
+++ b/src/brickstrap.sh
@@ -51,7 +51,7 @@ function brickstrap_create_tar()
         exit 1
     fi
 
-    # --exclude-ignore requires tar > 1.27.1, so first we check the tar version in
+    # --exclude-ignore requires tar >= 1.28, so first we check the tar version in
     # the docker image.
 
     echo "Checking docker image tar version..."
@@ -60,8 +60,8 @@ function brickstrap_create_tar()
         tar --version | head -1 | cut -d\  -f 4)"
     echo "tar $BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION"
 
-    SORTED_VERSION="$(echo "${BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION}"$'\n'"1.27.1" | sort -Vr | head -1)"
-    if [ "${SORTED_VERSION}" != "1.27.1" ]; then # BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION > 1.27.1
+    SORTED_VERSION="$(echo "${BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION}"$'\n'"1.28" | sort -V | head -1)"
+    if [ "${SORTED_VERSION}" = "1.28" ]; then # BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION >= 1.28
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-ignore .brickstrap-tar-exclude"
     elif docker run --rm --user root $BRICKSTRAP_DOCKER_IMAGE_NAME test -f /brickstrap/_tar-exclude; then
         BRICKSTRAP_TAR_EXCLUDE_OPTION="--exclude-from /brickstrap/_tar-exclude"


### PR DESCRIPTION
Since dpkg isn't available on non-debian systems it's better to use the build in `tar --version` command to check the tar version. Comparisation happens with the version-sort feature from coreutils `sort`.

Things I have tested:
* `BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION` output
* `SORTED_VERSION` output
* Setting `BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION=1.27`
* Setting `BRICKSTRAP_DOCKER_IMAGE_TAR_VERSION=1.28`